### PR TITLE
feat: Payment reference and for per handler

### DIFF
--- a/modules/govuk_pay_webform/govuk_pay_webform.module
+++ b/modules/govuk_pay_webform/govuk_pay_webform.module
@@ -16,6 +16,8 @@ function govuk_pay_webform_theme($existing, $type, $theme, $path) {
         'payment_amount' => NULL,
         'payment_status' => NULL,
         'payment_message' => NULL,
+        'payment_for' => NULL,
+        'payment_reference' => NULL,
         'confirmation_message' => NULL,
       ],
     ],

--- a/modules/govuk_pay_webform/govuk_pay_webform.services.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.services.yml
@@ -8,3 +8,4 @@ services:
       - '@request_stack'
       - '@entity_type.manager'
       - '@logger.factory'
+      - '@token'

--- a/modules/govuk_pay_webform/src/Controller/GovPayWebformController.php
+++ b/modules/govuk_pay_webform/src/Controller/GovPayWebformController.php
@@ -8,6 +8,7 @@ use Drupal\govuk_pay_webform\GovUkPayWebformService;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Utility\Token;
 
 /**
  * Page controller for displaying GOV.UK Pay content on behalf of Webform.
@@ -29,19 +30,30 @@ class GovPayWebformController extends ControllerBase {
   protected $paymentService;
 
   /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
    * Constructs a new GovPayWebformController object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\govuk_pay_webform\GovUkPayWebformService $payment_service
    *   The GOV.UK Pay Webform service.
+   * @param \Drupal\Core\Utility\Token $token
+   *   The token service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     GovUkPayWebformService $payment_service,
+    Token $token,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->paymentService = $payment_service;
+    $this->token = $token;
   }
 
   /**
@@ -50,7 +62,8 @@ class GovPayWebformController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('govuk_pay_webform.payment_service')
+      $container->get('govuk_pay_webform.payment_service'),
+      $container->get('token')
     );
   }
 
@@ -75,16 +88,36 @@ class GovPayWebformController extends ControllerBase {
       '#payment_amount' => NULL,
       '#payment_status' => NULL,
       '#payment_message' => NULL,
+      '#payment_for' => NULL,
+      '#payment_reference' => NULL,
       '#confirmation_message' => NULL,
     ];
 
     // Get the confirmation message from the GovPayHandler configuration.
     $webform = Webform::load($webform_id);
+    $webform_submission = NULL;
+
+    // Load the submission if available for token replacement.
+    if ($submission_id) {
+      $webform_submission = $this->entityTypeManager->getStorage('webform_submission')->load($submission_id);
+    }
+
     if ($webform) {
       foreach ($webform->getHandlers() as $handler) {
         if ($handler->getPluginId() === 'govuk_pay') {
           $configuration = $handler->getConfiguration();
+
+          // Get confirmation message.
           $confirmation_message = $configuration['settings']['confirmation_message'] ? $configuration['settings']['confirmation_message'] : NULL;
+          if ($confirmation_message && $webform_submission) {
+            // Replace tokens in the confirmation message.
+            $token_data = [
+              'webform' => $webform,
+              'webform_submission' => $webform_submission,
+            ];
+            $confirmation_message = $this->token->replace($confirmation_message, $token_data);
+          }
+
           if ($confirmation_message) {
             $data['#confirmation_message'] = new FormattableMarkup($confirmation_message, []);
           }
@@ -110,6 +143,8 @@ class GovPayWebformController extends ControllerBase {
     $data['#payment_amount'] = $payment_details['amount'];
     $data['#payment_status'] = $payment_details['status'];
     $data['#payment_message'] = $payment_details['message'];
+    $data['#payment_for'] = $payment_details['payment_for'];
+    $data['#payment_reference'] = $payment_details['payment_reference'];
 
     return $data;
   }

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -7,12 +7,13 @@ use GuzzleHttp\Psr7\Uri;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\govuk_pay\Entity\GovUkPayment;
 use Drupal\govuk_pay\ApiService;
-use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Utility\Token;
 use Drupal\Core\Url;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Component\Uuid\UuidInterface;
 
 /**
  * Service for GOV.UK Pay Webform operations.
@@ -62,6 +63,13 @@ class GovUkPayWebformService {
   protected $logger;
 
   /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
    * Constructs a new GovUkPayWebformService.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -76,6 +84,8 @@ class GovUkPayWebformService {
    *   The entity type manager.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
+   * @param \Drupal\Core\Utility\Token $token
+   *   The token service.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
@@ -84,6 +94,7 @@ class GovUkPayWebformService {
     RequestStack $request_stack,
     EntityTypeManagerInterface $entity_type_manager,
     LoggerChannelFactoryInterface $logger_factory,
+    Token $token,
   ) {
     $this->configFactory = $config_factory;
     $this->apiService = $api_service;
@@ -91,6 +102,7 @@ class GovUkPayWebformService {
     $this->requestStack = $request_stack;
     $this->entityTypeManager = $entity_type_manager;
     $this->logger = $logger_factory->get('govuk_pay_webform');
+    $this->token = $token;
   }
 
   /**
@@ -112,9 +124,6 @@ class GovUkPayWebformService {
     $config = $this->configFactory->get('govuk_pay.settings');
 
     // Validate required parameters.
-    if (empty($config->get('gov_pay__reference'))) {
-      throw new \RuntimeException('GOV.UK Pay reference is not configured. This is a required field on /admin/config/govuk_pay/settings.');
-    }
     if (empty($config->get('gov_pay__apikey'))) {
       throw new \RuntimeException('GOV.UK Pay API key is not configured. This is a required field on /admin/config/govuk_pay/settings.');
     }
@@ -127,9 +136,15 @@ class GovUkPayWebformService {
       throw new \RuntimeException('Payment amount could not be determined.');
     }
 
-    $message = $configuration['payment_message'] ?? $webform->label();
-    if (strlen($message) > 254) {
-      $message = substr($message, 0, 251) . '...';
+    // Process the payment description with token replacement.
+    $payment_for = $this->replaceTokens($configuration['payment_for'] ?? '', $webform_submission);
+    if (empty($payment_for)) {
+      $payment_for = $webform->label();
+    }
+
+    // Ensure the description doesn't exceed GOV.UK Pay's limit.
+    if (strlen($payment_for) > 254) {
+      $payment_for = substr($payment_for, 0, 251) . '...';
     }
 
     $uuid = $this->uuidService->generate();
@@ -142,10 +157,22 @@ class GovUkPayWebformService {
     $url_object = Url::fromRoute('govuk_pay_webform.confirmation_page', $route_params, ['absolute' => TRUE]);
     $returnUrl = new Uri($url_object->toString());
 
+    // Process payment reference with token replacement.
+    $payment_reference = $this->replaceTokens($configuration['payment_reference'] ?? '', $webform_submission);
+
+    // If payment_reference is empty, use the global reference
+    // from settings as fallback.
+    if (empty($payment_reference)) {
+      if (empty($config->get('gov_pay__reference'))) {
+        throw new \RuntimeException('GOV.UK Pay reference is not configured. This is a required field on /admin/config/govuk_pay/settings.');
+      }
+      $payment_reference = $config->get('gov_pay__reference');
+    }
+
     $payment_response = $this->apiService->createPayment(
       $amount,
-      $config->get('gov_pay__reference'),
-      $message,
+      $payment_reference,
+      $payment_for,
       $returnUrl
     );
 
@@ -156,6 +183,8 @@ class GovUkPayWebformService {
       'status' => $payment_response->getState()->getStatus(),
       'webform_id' => $webform->id(),
       'submission_id' => $sid,
+      'payment_for' => $payment_for,
+      'payment_reference' => $payment_reference,
     ]);
     $payment->save();
 
@@ -253,7 +282,8 @@ class GovUkPayWebformService {
    *   Submission ID.
    *
    * @return array
-   *   Payment details array with keys for payment_id, amount, status, and message.
+   *   Payment details array with keys for payment_id,
+   *   amount, status, and message.
    */
   public function getPaymentDetails($uuid, $webform_id, $submission_id) {
     $details = [
@@ -261,6 +291,8 @@ class GovUkPayWebformService {
       'amount' => NULL,
       'status' => NULL,
       'message' => NULL,
+      'payment_for' => NULL,
+      'payment_reference' => NULL,
     ];
 
     $payment = $this->getPaymentByUuid($uuid, $webform_id, $submission_id);
@@ -280,9 +312,48 @@ class GovUkPayWebformService {
       else {
         $details['amount'] = 'Payment not found';
       }
+
+      // Get payment_for and payment_reference from the entity if available.
+      if ($payment->hasField('payment_for') && !$payment->get('payment_for')->isEmpty()) {
+        $details['payment_for'] = $payment->get('payment_for')->getValue()[0]['value'];
+      }
+
+      if ($payment->hasField('payment_reference') && !$payment->get('payment_reference')->isEmpty()) {
+        $details['payment_reference'] = $payment->get('payment_reference')->getValue()[0]['value'];
+      }
+      // If payment_reference is still empty, use the global reference from
+      // settings as fallback.
+      elseif (empty($details['payment_reference'])) {
+        $config = $this->configFactory->get('govuk_pay.settings');
+        $details['payment_reference'] = $config->get('gov_pay__reference');
+      }
     }
 
     return $details;
+  }
+
+  /**
+   * Replace tokens in text with webform submission values.
+   *
+   * @param string $text
+   *   The text to process.
+   * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
+   *   A webform submission.
+   *
+   * @return string
+   *   Text with tokens replaced.
+   */
+  protected function replaceTokens($text, WebformSubmissionInterface $webform_submission) {
+    if (empty($text) || strpos($text, '[') === FALSE) {
+      return $text;
+    }
+
+    $token_data = [
+      'webform' => $webform_submission->getWebform(),
+      'webform_submission' => $webform_submission,
+    ];
+
+    return $this->token->replace($text, $token_data);
   }
 
 }

--- a/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
+++ b/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
@@ -60,6 +60,13 @@ class GovPayHandler extends WebformHandlerBase {
   protected $logger;
 
   /**
+   * The token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -69,6 +76,7 @@ class GovPayHandler extends WebformHandlerBase {
     $instance->uuidService = $container->get('uuid');
     $instance->requestStack = $container->get('request_stack');
     $instance->logger = $container->get('logger.factory')->get('govuk_pay_webform');
+    $instance->token = $container->get('token');
     return $instance;
   }
 
@@ -83,7 +91,8 @@ class GovPayHandler extends WebformHandlerBase {
       'amount_element' => '',
       'amount_static' => '',
       'default_markup' => '',
-      'payment_message' => '',
+      'payment_for' => '',
+      'payment_reference' => '',
       'confirmation_message' => '',
     ] + parent::defaultConfiguration();
   }
@@ -185,19 +194,40 @@ class GovPayHandler extends WebformHandlerBase {
       '#parents' => ['settings'],
     ];
 
-    $form['messages']['payment_message'] = [
+    $form['messages']['payment_for'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Payment message'),
-      '#description' => $this->t('Text to display to the user on the GOV.UK Pay page.'),
-      '#default_value' => $this->configuration['payment_message'],
+      '#title' => $this->t('Payment for'),
+      '#description' => $this->t('Text to display to the user on the GOV.UK Pay page. Will also show on the receipt email sent from the gateway prefixed with the label "Payment for:". You may use tokens.'),
+      '#default_value' => $this->configuration['payment_for'],
+    ];
+
+    $form['messages']['payment_reference'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Payment reference'),
+      '#description' => $this->t('Will be displayed on the confirmation page and also in the email send from the gateway, prefixed with the label "Reference:". You may use tokens.'),
+      '#default_value' => $this->configuration['payment_reference'],
     ];
 
     $form['messages']['confirmation_message'] = [
       '#type' => 'webform_html_editor',
       '#title' => $this->t('Confirmation message'),
-      '#description' => $this->t('Text to display to the user once they return to the site from GOV.UK Pay.'),
+      '#description' => $this->t('Additional text to display to the user once they return to the site from GOV.UK Pay. You may use tokens.'),
       '#default_value' => $this->configuration['confirmation_message'],
     ];
+
+    // Add token help if module is available.
+    if (\Drupal::moduleHandler()->moduleExists('token')) {
+      $form['messages']['token_help'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Available tokens'),
+        '#description' => $this->t('Use these tokens to include submission data in the payment information.'),
+        '#open' => FALSE,
+      ];
+      $form['messages']['token_help']['token_tree'] = [
+        '#theme' => 'token_tree_link',
+        '#token_types' => ['webform', 'webform_submission'],
+      ];
+    }
 
     return $form;
   }

--- a/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
+++ b/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
@@ -191,27 +191,28 @@ class GovPayHandler extends WebformHandlerBase {
     $form['messages'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Messages'),
+      '#description' => $this->t('Messages to display to the user on the GOV.UK Pay page and confirmation page. Token can be used in any of these fields.'),
       '#parents' => ['settings'],
     ];
 
     $form['messages']['payment_for'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Payment for'),
-      '#description' => $this->t('Text to display to the user on the GOV.UK Pay page. Will also show on the receipt email sent from the gateway prefixed with the label "Payment for:". You may use tokens.'),
+      '#description' => $this->t('Text to display to the user on the GOV.UK Pay page. Will also show on the receipt email sent from the gateway prefixed with the label "Payment for:"'),
       '#default_value' => $this->configuration['payment_for'],
     ];
 
     $form['messages']['payment_reference'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Payment reference'),
-      '#description' => $this->t('Will be displayed on the confirmation page and also in the email send from the gateway, prefixed with the label "Reference:". You may use tokens.'),
+      '#description' => $this->t('Will be displayed on the confirmation page and also in the email send from the gateway, prefixed with the label "Reference:"'),
       '#default_value' => $this->configuration['payment_reference'],
     ];
 
     $form['messages']['confirmation_message'] = [
       '#type' => 'webform_html_editor',
       '#title' => $this->t('Confirmation message'),
-      '#description' => $this->t('Additional text to display to the user once they return to the site from GOV.UK Pay. You may use tokens.'),
+      '#description' => $this->t('Additional text to display to the user once they return to the site from GOV.UK Pay.'),
       '#default_value' => $this->configuration['confirmation_message'],
     ];
 

--- a/modules/govuk_pay_webform/templates/govuk-pay-webform--govuk-confirmation-page.html.twig
+++ b/modules/govuk_pay_webform/templates/govuk-pay-webform--govuk-confirmation-page.html.twig
@@ -5,7 +5,13 @@
     </div>
     <div id="default_message">
         <p>
-          Payment ID: <strong>{{ payment_id }}</strong>
+          GOV.UK Payment ID: <strong>{{ payment_id }}</strong>
+        </p>
+        <p>
+          Payment Reference: <strong>{{ payment_reference }}</strong>
+        </p>
+        <p>
+          Payment For: <strong>{{ payment_for }}</strong>
         </p>
         <p>
             Your payment of {{ payment_amount }} currently has

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -37,6 +37,8 @@ use Drupal\Core\Entity\ContentEntityBase;
  *     "status" = "status",
  *     "amount" = "amount",
  *     "uid" = "uid",
+ *     "payment_for" = "payment_for",
+ *     "payment_reference" = "payment_reference",
  *     "owner" = "uid",
  *   },
  *   config_export = {
@@ -47,6 +49,8 @@ use Drupal\Core\Entity\ContentEntityBase;
  *     "submission_id",
  *     "status",
  *     "amount",
+ *     "payment_for",
+ *     "payment_reference",
  *     "uid",
  *   }
  * )
@@ -175,6 +179,36 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'label' => 'above',
         'type' => 'string',
         'weight' => -6,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['payment_for'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Payment For'))
+      ->setDescription(t('The payment description shown to the user.'))
+      ->setSettings([
+        'default_value' => '',
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'string',
+        'weight' => -5,
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['payment_reference'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Payment Reference'))
+      ->setDescription(t('The payment reference shown to the user.'))
+      ->setSettings([
+        'default_value' => '',
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'string',
+        'weight' => -4,
       ])
       ->setDisplayConfigurable('view', TRUE);
 

--- a/src/Form/GovUkPayGeneralSettingsForm.php
+++ b/src/Form/GovUkPayGeneralSettingsForm.php
@@ -48,7 +48,7 @@ class GovUkPayGeneralSettingsForm extends ConfigFormBase {
       '#required' => TRUE,
       '#type' => 'textfield',
       '#default_value' => $config->get('gov_pay__reference'),
-      '#description' => $this->t('The payment reference assigned to all GOV.UK Pay transactions on this site.'),
+      '#description' => $this->t('The fallback payment reference assigned to GOV.UK Pay transactions if not set individually on the handler.'),
     ];
 
     return parent::buildForm($form, $form_state);


### PR DESCRIPTION
## What does this change?

Adds a `payment_for` and `payment_reference` field to the handler which also accept tokens. This is then used to populate the data send to the gateway and is also displayed on confirmation

Ref https://github.com/localgovdrupal/govuk_pay/issues/5