### PR TITLE
feat: Add metadata to payment

### DIFF
--- a/modules/govuk_pay_webform/README.md
+++ b/modules/govuk_pay_webform/README.md
@@ -52,6 +52,14 @@ Choose how the payment amount will be determined:
 - **Payment message**: A custom message displayed on the GOV.UK Pay payment page
 - **Confirmation message**: A custom message displayed on the confirmation page
 
+#### Metadata
+- **Metadata key/value pairs**: Optional metadata that will be sent with the payment to GOV.UK Pay
+  - You can add multiple key/value pairs by clicking the "Add another metadata item" button
+  - Both keys and values support token replacement, allowing you to include dynamic data from the webform submission
+  - Keys must be strings and values must be scalar (string, number, boolean)
+  - This metadata will be available in GOV.UK Pay reports and can be used for filtering and reporting purposes
+  - Example use cases: tracking department codes, cost centers, service identifiers, or any other custom data needed for reconciliation
+
 ## How It Works
 1. When a user submits a webform with the govuk_pay webform handler, the normal webform submission process is intercepted when the handler triggers
 2. The user is redirected to GOV.UK Pay to complete their payment

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -187,11 +187,28 @@ class GovUkPayWebformService {
       $payment_reference = $config->get('gov_pay__reference');
     }
 
+    // Process metadata from configuration.
+    $metadata = [];
+    if (!empty($configuration['metadata']) && is_array($configuration['metadata'])) {
+      foreach ($configuration['metadata'] as $item) {
+        if (!empty($item['key']) && isset($item['value'])) {
+          // Process tokens in both key and value.
+          $key = $this->replaceTokens($item['key'], $webform_submission);
+          $value = $this->replaceTokens($item['value'], $webform_submission);
+          // Only add non-empty keys with defined values.
+          if (!empty($key) && $value !== '') {
+            $metadata[$key] = $value;
+          }
+        }
+      }
+    }
+
     $payment_response = $this->apiService->createPayment(
       $amount,
       $payment_reference,
       $payment_for,
-      $returnUrl
+      $returnUrl,
+      $metadata
     );
 
     $payment = GovUkPayment::create([

--- a/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
+++ b/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
@@ -102,6 +102,7 @@ class GovPayHandler extends WebformHandlerBase {
       'payment_for' => '',
       'payment_reference' => '',
       'confirmation_message' => '',
+      'metadata' => [],
     ] + parent::defaultConfiguration();
   }
 
@@ -224,6 +225,40 @@ class GovPayHandler extends WebformHandlerBase {
       '#default_value' => $this->configuration['confirmation_message'],
     ];
 
+    // Add metadata field for key/value pairs.
+    $form['metadata_container'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Metadata'),
+      '#description' => $this->t('Add optional metadata to be sent with the payment. Keys must be strings and values must be scalar (string, number, boolean).'),
+      '#open' => TRUE,
+    ];
+
+    // Use Drupal's multiple values pattern.
+    $form['metadata_container']['metadata'] = [
+      '#type' => 'webform_multiple',
+      '#title' => $this->t('Metadata key/value pairs'),
+      '#description' => $this->t('Add optional metadata to be sent with the payment. Keys must be strings and values must be scalar (string, number, boolean). Tokens can also be used but must resolve to a scalar value.'),
+      '#title_display' => 'invisible',
+      '#default_value' => $this->configuration['metadata'] ?? [],
+      '#add_more_text' => $this->t('Add another metadata item'),
+      '#empty_items' => 1,
+      '#no_items_message' => $this->t('No metadata has been added.'),
+      '#element' => [
+        'key' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Key'),
+          '#placeholder' => $this->t('Enter metadata key'),
+          '#maxlength' => 128,
+        ],
+        'value' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Value'),
+          '#placeholder' => $this->t('Enter metadata value'),
+          '#maxlength' => 255,
+        ],
+      ],
+    ];
+
     // Add token help if module is available.
     if (\Drupal::moduleHandler()->moduleExists('token')) {
       $form['messages']['token_help'] = [
@@ -242,6 +277,38 @@ class GovPayHandler extends WebformHandlerBase {
   }
 
   /**
+   * Ajax callback for the metadata table.
+   */
+  public function metadataTableAjaxCallback(array &$form, FormStateInterface $form_state) {
+    return $form['metadata_container']['metadata'];
+  }
+
+  /**
+   * Submit handler for adding more metadata rows.
+   */
+  public function addMetadataCallback(array &$form, FormStateInterface $form_state) {
+    $metadata = $form_state->get('metadata');
+    $metadata[] = ['key' => '', 'value' => ''];
+    $form_state->set('metadata', $metadata);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for removing metadata rows.
+   */
+  public function removeMetadataCallback(array &$form, FormStateInterface $form_state) {
+    $trigger = $form_state->getTriggeringElement();
+    $delta = str_replace('remove_metadata_', '', $trigger['#name']);
+
+    $metadata = $form_state->get('metadata');
+    unset($metadata[$delta]);
+    // Re-index the array.
+    $metadata = array_values($metadata);
+    $form_state->set('metadata', $metadata);
+    $form_state->setRebuild();
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
@@ -249,12 +316,16 @@ class GovPayHandler extends WebformHandlerBase {
 
     $values = $form_state->getValues();
 
+    // Get metadata values.
+    if (isset($values['metadata_container']['metadata'])) {
+      $this->configuration['metadata'] = $values['metadata_container']['metadata'];
+    }
+
     foreach ($this->configuration as $name => $value) {
       if (isset($values[$name])) {
         $this->configuration[$name] = $values[$name];
       }
     }
-
   }
 
   /**

--- a/src/ApiService.php
+++ b/src/ApiService.php
@@ -7,7 +7,6 @@ use Swagger\Client\Model\Refund;
 use Swagger\Client\Model\PaymentWithAllLinks;
 use Swagger\Client\Model\PaymentRefundRequest;
 use Swagger\Client\Model\PaymentEvents;
-use Swagger\Client\Model\ExternalMetadata;
 use Swagger\Client\Model\CreatePaymentResult;
 use Swagger\Client\Model\CreateCardPaymentRequest;
 use GuzzleHttp\Psr7\Uri;
@@ -129,11 +128,7 @@ class ApiService {
       $payment_request->setReturnUrl((string) $return_url);
 
       if (!empty($metadata)) {
-        $external_metadata = new ExternalMetadata();
-        foreach ($metadata as $key => $value) {
-          $external_metadata[$key] = $value;
-        }
-        $payment_request->setMetadata($external_metadata);
+        $payment_request->setMetadata($metadata);
       }
 
       // Create the payment.


### PR DESCRIPTION
## What does this change?

This adds a new metadata field on the handler which takes sets of key/value pairs and passes them through to the payment gateway. These can then be viewed in the gateway's admin page and be used for filtering.

![image](https://github.com/user-attachments/assets/3e63f379-34fe-40f3-9056-c9a638ed99b6)

![image](https://github.com/user-attachments/assets/aa55ba73-8cd4-4643-9e40-1387a5a9ff53)
