### PR TITLE
feat: Pass through tokenised cardholder details

### DIFF
--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -171,7 +171,7 @@ class GovUkPayWebformService {
     // Store payment data in the session.
     $this->setPaymentData($payment_data);
 
-    // Create the return URL without parameters.
+    // Create the return URL.
     $url_object = Url::fromRoute('govuk_pay_webform.confirmation_page', [], ['absolute' => TRUE]);
     $returnUrl = new Uri($url_object->toString());
 
@@ -203,12 +203,81 @@ class GovUkPayWebformService {
       }
     }
 
+    // Process email field with token replacement.
+    $email = NULL;
+    if (!empty($configuration['fields']['email'])) {
+      $email = $this->replaceTokens($configuration['fields']['email'], $webform_submission, TRUE);
+    }
+
+    // Process prefilled cardholder details.
+    $prefilled_cardholder_details = NULL;
+    $cardholder_name = NULL;
+    $billing_address = NULL;
+
+    // Check if name field is configured and has a value.
+    if (!empty($configuration['fields']['name'])) {
+      $cardholder_name = $this->replaceTokens($configuration['fields']['name'], $webform_submission, TRUE);
+    }
+
+    // Check if address fields are configured and have values.
+    $line1 = !empty($configuration['fields']['address']['line1'])
+      ? $this->replaceTokens($configuration['fields']['address']['line1'], $webform_submission, TRUE)
+      : NULL;
+    $line2 = !empty($configuration['fields']['address']['line2'])
+      ? $this->replaceTokens($configuration['fields']['address']['line2'], $webform_submission, TRUE)
+      : NULL;
+    $postcode = !empty($configuration['fields']['address']['postcode'])
+      ? $this->replaceTokens($configuration['fields']['address']['postcode'], $webform_submission, TRUE)
+      : NULL;
+    $city = !empty($configuration['fields']['address']['city'])
+      ? $this->replaceTokens($configuration['fields']['address']['city'], $webform_submission, TRUE)
+      : NULL;
+    $country = !empty($configuration['fields']['address']['country'])
+      ? $this->replaceTokens($configuration['fields']['address']['country'], $webform_submission, TRUE)
+      : 'GB';
+
+    // Only create billing address if at least line1 is provided.
+    if (!empty($line1)) {
+      $billing_address = [
+        'line1' => $line1,
+      ];
+
+      // Add optional address fields if they have values.
+      if (!empty($line2)) {
+        $billing_address['line2'] = $line2;
+      }
+      if (!empty($postcode)) {
+        $billing_address['postcode'] = $postcode;
+      }
+      if (!empty($city)) {
+        $billing_address['city'] = $city;
+      }
+      if (!empty($country)) {
+        $billing_address['country'] = $country;
+      }
+    }
+
+    // Create prefilled_cardholder_details if we have either name or address.
+    if (!empty($cardholder_name) || !empty($billing_address)) {
+      $prefilled_cardholder_details = [];
+
+      if (!empty($cardholder_name)) {
+        $prefilled_cardholder_details['cardholder_name'] = $cardholder_name;
+      }
+
+      if (!empty($billing_address)) {
+        $prefilled_cardholder_details['billing_address'] = $billing_address;
+      }
+    }
+
     $payment_response = $this->apiService->createPayment(
       $amount,
       $payment_reference,
       $payment_for,
       $returnUrl,
-      $metadata
+      $metadata,
+      $email,
+      $prefilled_cardholder_details
     );
 
     $payment = GovUkPayment::create([
@@ -435,11 +504,13 @@ class GovUkPayWebformService {
    *   The text to process.
    * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
    *   A webform submission.
+   * @param bool $plain_text
+   *   Whether to return plain text (TRUE) or HTML (FALSE).
    *
    * @return string
    *   Text with tokens replaced.
    */
-  protected function replaceTokens($text, WebformSubmissionInterface $webform_submission) {
+  protected function replaceTokens($text, WebformSubmissionInterface $webform_submission, $plain_text = FALSE) {
     if (empty($text) || strpos($text, '[') === FALSE) {
       return $text;
     }
@@ -449,6 +520,12 @@ class GovUkPayWebformService {
       'webform_submission' => $webform_submission,
     ];
 
+    // Use replacePlain for plain text output (no HTML encoding).
+    if ($plain_text) {
+      return $this->token->replacePlain($text, $token_data);
+    }
+
+    // Use replace for HTML output (with HTML encoding).
     return $this->token->replace($text, $token_data);
   }
 

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -322,24 +322,20 @@ class GovUkPayWebformService {
   public function calculateAmount(WebformSubmissionInterface $webform_submission, array $configuration) {
     $amount = 0;
 
-    switch ($configuration['amount_provider']) {
-      case 'element':
-        $element_name = $configuration['amount_element'];
-        if (!empty($element_name)) {
-          $value = $webform_submission->getElementData($element_name);
-          if (is_numeric($value)) {
-            // Convert to pence (multiply by 100 and ensure integer).
-            $amount = (int) (floatval($value) * 100);
-          }
-        }
-        break;
+    // Get the amount from the configuration.
+    $amount_value = $configuration['fields']['amount'] ?? '';
 
-      case 'static':
-        if (!empty($configuration['amount_static']) && is_numeric($configuration['amount_static'])) {
-          // Convert to pence (multiply by 100 and ensure integer).
-          $amount = (int) (floatval($configuration['amount_static']) * 100);
-        }
-        break;
+    // Process tokens in the amount value.
+    if (!empty($amount_value)) {
+      $processed_amount = $this->token->replace($amount_value, [
+        'webform' => $webform_submission->getWebform(),
+        'webform_submission' => $webform_submission,
+      ]);
+
+      if (is_numeric($processed_amount)) {
+        // Convert to pence (multiply by 100 and ensure integer).
+        $amount = (int) (floatval($processed_amount) * 100);
+      }
     }
 
     return $amount;

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -318,6 +318,9 @@ class GovUkPayWebformService {
    *
    * @return int
    *   The payment amount in pence.
+   *
+   * @throws \RuntimeException
+   *   Throws exception if payment amount cannot be determined.
    */
   public function calculateAmount(WebformSubmissionInterface $webform_submission, array $configuration) {
     $amount = 0;
@@ -325,17 +328,24 @@ class GovUkPayWebformService {
     // Get the amount from the configuration.
     $amount_value = $configuration['fields']['amount'] ?? '';
 
-    // Process tokens in the amount value.
     if (!empty($amount_value)) {
-      $processed_amount = $this->token->replace($amount_value, [
-        'webform' => $webform_submission->getWebform(),
-        'webform_submission' => $webform_submission,
-      ]);
+      // Use the replaceTokens method with plain_text=TRUE.
+      // to avoid HTML encoding.
+      $processed_amount = $this->replaceTokens(
+        $amount_value,
+        $webform_submission,
+        TRUE
+      );
 
       if (is_numeric($processed_amount)) {
         // Convert to pence (multiply by 100 and ensure integer).
         $amount = (int) (floatval($processed_amount) * 100);
       }
+    }
+
+    // If we still don't have a valid amount, throw an exception.
+    if ($amount <= 0) {
+      throw new \RuntimeException('Payment amount could not be determined. Please check your webform configuration.');
     }
 
     return $amount;

--- a/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
+++ b/modules/govuk_pay_webform/src/Plugin/WebformHandler/GovPayHandler.php
@@ -95,9 +95,18 @@ class GovPayHandler extends WebformHandlerBase {
     return [
       'wrapper_attributes' => [],
         // Component settings.
-      'amount_provider' => '',
-      'amount_element' => '',
-      'amount_static' => '',
+      'fields' => [
+        'amount' => '',
+        'name' => '',
+        'email' => '',
+        'address' => [
+          'line1' => '',
+          'line2' => '',
+          'postcode' => '',
+          'city' => '',
+          'country' => 'GB',
+        ],
+      ],
       'default_markup' => '',
       'payment_for' => '',
       'payment_reference' => '',
@@ -143,58 +152,75 @@ class GovPayHandler extends WebformHandlerBase {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
 
-    $form['amount'] = [
+    $form['fields'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Payment Amount'),
-      '#parents' => ['settings'],
+      '#title' => $this->t('Payment Fields'),
+      '#description' => $this->t('Configure fields that will be sent to the GOV.UK Pay gateway.'),
+      '#parents' => ['settings', 'fields'],
     ];
 
-    $form['amount']['amount_provider'] = [
-      '#type' => 'radios',
-      '#required' => TRUE,
-      '#title' => $this->t('Amount source'),
-      '#description' => $this->t('Choose how the amount of the GOV.UK Payment will be provided.'),
-      '#default_value' => $this->configuration['amount_provider'],
-      '#options' => [
-        'element' => $this->t('Webform element'),
-        'static' => $this->t('Fixed amount'),
-      ],
-    ];
-
-    $amount_provider_element_key = ':input[name="settings[amount_provider]"]';
-
-    $form['amount']['amount_element'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Element'),
-      '#description' => $this->t('Choose the element that will provide the amount for the payment.'),
-      '#default_value' => $this->configuration['amount_element'],
-      '#options' => $this->valueElements(),
-      '#states' => [
-        'visible' => [
-          $amount_provider_element_key => ['value' => 'element'],
-        ],
-        'required' => [
-          $amount_provider_element_key => ['value' => 'element'],
-        ],
-      ],
-    ];
-    $form['amount']['amount_static'] = [
+    $form['fields']['amount'] = [
       '#type' => 'textfield',
-      '#attributes' => [
-        'type' => 'number',
-        'min' => 1,
-      ],
       '#title' => $this->t('Amount'),
-      '#description' => $this->t('Choose the amount that a payment will be made for.'),
-      '#default_value' => $this->configuration['amount_static'],
-      '#states' => [
-        'visible' => [
-          $amount_provider_element_key => ['value' => 'static'],
-        ],
-        'required' => [
-          $amount_provider_element_key => ['value' => 'static'],
-        ],
-      ],
+      '#description' => $this->t('Enter the amount for the payment. You can use tokens to map webform fields (e.g., [webform_submission:values:your_field_name]). The value will be converted to pence.'),
+      '#default_value' => $this->configuration['fields']['amount'] ?? '',
+      '#required' => TRUE,
+    ];
+
+    $form['fields']['email'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Email'),
+      '#description' => $this->t('Enter a token to map to the customer email field (e.g., [webform_submission:values:email]). This will pre-fill the email field on the payment page.'),
+      '#default_value' => $this->configuration['fields']['email'] ?? '',
+    ];
+
+    $form['fields']['name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Cardholder Name'),
+      '#description' => $this->t('Enter a token to map to the cardholder name field (e.g., [webform_submission:values:name]). This will pre-fill the cardholder name on the payment page.'),
+      '#default_value' => $this->configuration['fields']['name'] ?? '',
+    ];
+
+    $form['fields']['address'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Billing Address'),
+      '#description' => $this->t('Configure the billing address fields that will be pre-filled on the payment page.'),
+      '#open' => TRUE,
+    ];
+
+    $form['fields']['address']['line1'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Address Line 1'),
+      '#description' => $this->t('Enter a token to map to the address line 1 field (e.g., [webform_submission:values:address_line1]).'),
+      '#default_value' => $this->configuration['fields']['address']['line1'] ?? '',
+    ];
+
+    $form['fields']['address']['line2'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Address Line 2'),
+      '#description' => $this->t('Enter a token to map to the address line 2 field (e.g., [webform_submission:values:address_line2]).'),
+      '#default_value' => $this->configuration['fields']['address']['line2'] ?? '',
+    ];
+
+    $form['fields']['address']['postcode'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Postcode'),
+      '#description' => $this->t('Enter a token to map to the postcode field (e.g., [webform_submission:values:postcode]).'),
+      '#default_value' => $this->configuration['fields']['address']['postcode'] ?? '',
+    ];
+
+    $form['fields']['address']['city'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('City'),
+      '#description' => $this->t('Enter a token to map to the city field (e.g., [webform_submission:values:city]).'),
+      '#default_value' => $this->configuration['fields']['address']['city'] ?? '',
+    ];
+
+    $form['fields']['address']['country'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Country'),
+      '#description' => $this->t('Enter a token to map to the country field or a two-letter country code (e.g., GB for United Kingdom).'),
+      '#default_value' => $this->configuration['fields']['address']['country'] ?? 'GB',
     ];
 
     $form['messages'] = [
@@ -340,25 +366,22 @@ class GovPayHandler extends WebformHandlerBase {
   protected function getAmount(WebformSubmissionInterface $webform_submission) {
     $amount = 0;
 
-    switch ($this->configuration['amount_provider']) {
-      case 'element':
-        $element_name = $this->configuration['amount_element'];
-        if (!empty($element_name)) {
-          $value = $webform_submission->getElementData($element_name);
-          if (is_numeric($value)) {
-            // Convert to pence (multiply by 100 and ensure integer).
-            $amount = (int) (floatval($value) * 100);
-          }
-        }
-        break;
+    // Get the amount from the configuration.
+    $amount_value = $this->configuration['fields']['amount'] ?? '';
 
-      case 'static':
-        if (!empty($this->configuration['amount_static']) && is_numeric($this->configuration['amount_static'])) {
-          // Convert to pence (multiply by 100 and ensure integer).
-          $amount = (int) (floatval($this->configuration['amount_static']) * 100);
-        }
-        break;
+    // Process tokens in the amount value.
+    if (!empty($amount_value)) {
+      $processed_amount = $this->token->replace($amount_value, [
+        'webform' => $webform_submission->getWebform(),
+        'webform_submission' => $webform_submission,
+      ]);
+
+      if (is_numeric($processed_amount)) {
+        // Convert to pence (multiply by 100 and ensure integer).
+        $amount = (int) (floatval($processed_amount) * 100);
+      }
     }
+
     return $amount;
   }
 

--- a/src/ApiService.php
+++ b/src/ApiService.php
@@ -85,6 +85,10 @@ class ApiService {
    * @param array $metadata
    *   Optional metadata to include with the payment.
    *   Keys must be strings, values must be scalar.
+   * @param string|null $email
+   *   Optional email address to pre-fill on the payment page.
+   * @param array|null $prefilled_cardholder_details
+   *   Optional cardholder details to pre-fill on the payment page.
    *
    * @return \Swagger\Client\Model\CreatePaymentResult
    *   The payment result.
@@ -94,7 +98,7 @@ class ApiService {
    * @throws \RuntimeException
    *   Thrown when the payment creation fails.
    */
-  public function createPayment($amount, string $reference, string $description, Uri $return_url, array $metadata = []): CreatePaymentResult {
+  public function createPayment($amount, string $reference, string $description, Uri $return_url, array $metadata = [], ?string $email = NULL, ?array $prefilled_cardholder_details = NULL): CreatePaymentResult {
     try {
       // Validate input parameters.
       if (!is_numeric($amount) || $amount <= 0) {
@@ -129,6 +133,16 @@ class ApiService {
 
       if (!empty($metadata)) {
         $payment_request->setMetadata($metadata);
+      }
+
+      // Add email if provided.
+      if (!empty($email)) {
+        $payment_request->setEmail($email);
+      }
+
+      // Add prefilled cardholder details if provided.
+      if (!empty($prefilled_cardholder_details)) {
+        $payment_request->setPrefilledCardholderDetails($prefilled_cardholder_details);
       }
 
       // Create the payment.


### PR DESCRIPTION
## What does this change?

This adds cardholder details (email, name, address) fields to the webform handler which can accept Drupal tokens. This means you can map any of the field values from the submission to pre-populate the gateway fields. For example:

![image](https://github.com/user-attachments/assets/0fd0c059-a6af-4edf-90d8-792f8ad5e17d)
