### PR TITLE
feat: Revisions and update status

### DIFF
--- a/modules/govuk_pay_webform/govuk_pay_webform.services.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.services.yml
@@ -10,6 +10,7 @@ services:
       - '@logger.factory'
       - '@tempstore.private'
       - '@token'
+      - '@current_user'
   govuk_pay_webform.access_checker:
     class: Drupal\govuk_pay_webform\Access\GovPayWebformAccess
     arguments: ['@current_user', '@tempstore.private']

--- a/modules/govuk_pay_webform/src/Controller/GovPayWebformController.php
+++ b/modules/govuk_pay_webform/src/Controller/GovPayWebformController.php
@@ -200,6 +200,42 @@ class GovPayWebformController extends ControllerBase {
         $data['#payment_for'] = $payment_details['payment_for'];
         $data['#payment_reference'] = $payment_details['payment_reference'];
         $data['#cache']['contexts'][] = 'session';
+
+        // Update Payment entity with status from payment details.
+        if (!empty($payment_details['payment_id']) && !empty($payment_details['status'])) {
+          try {
+            // Load the payment entity by UUID.
+            $payment_storage = $this->entityTypeManager->getStorage('govukpayment');
+            $payment_entities = $payment_storage->loadByProperties(['uuid' => $uuid]);
+
+            if (!empty($payment_entities)) {
+              /** @var \Drupal\govuk_pay\Entity\GovUkPayment $payment_entity */
+              $payment_entity = reset($payment_entities);
+
+              // Only update if the status has changed.
+              if ($payment_entity->get('status')->value !== $payment_details['status']) {
+                $payment_entity->setNewRevision(TRUE);
+                $payment_entity->setRevisionCreationTime(time());
+                $payment_entity->setRevisionLogMessage('Payment status updated from ' . $payment_entity->get('status')->value . ' to ' . $payment_details['status']);
+                // Set the revision owner to the current user if available.
+                $current_user = $this->currentUser();
+                if ($current_user) {
+                  $payment_entity->setRevisionUserId($current_user->id());
+                }
+                $payment_entity->set('status', $payment_details['status']);
+                $payment_entity->save();
+                $this->logger->info('Payment status updated for UUID: @uuid from @old_status to @new_status', [
+                  '@uuid' => $uuid,
+                  '@old_status' => $payment_entity->get('status')->value,
+                  '@new_status' => $payment_details['status'],
+                ]);
+              }
+            }
+          }
+          catch (\Exception $e) {
+            $this->logger->error('Error updating payment entity status: @error', ['@error' => $e->getMessage()]);
+          }
+        }
       }
     }
     catch (\Exception $e) {

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -10,6 +10,7 @@ use Drupal\govuk_pay\ApiService;
 use Drupal\Core\Utility\Token;
 use Drupal\Core\Url;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -29,7 +30,7 @@ class GovUkPayWebformService {
   protected $configFactory;
 
   /**
-   * The GOV.UK Pay API service.
+   * The API service.
    *
    * @var \Drupal\govuk_pay\ApiService
    */
@@ -57,14 +58,21 @@ class GovUkPayWebformService {
   protected $entityTypeManager;
 
   /**
-   * The logger service.
+   * The logger factory.
    *
-   * @var \Psr\Log\LoggerInterface
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 
   /**
-   * The private temp store.
+   * The tempstore service.
    *
    * @var \Drupal\Core\TempStore\PrivateTempStore
    */
@@ -78,12 +86,19 @@ class GovUkPayWebformService {
   protected $token;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
    * Constructs a new GovUkPayWebformService.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
    * @param \Drupal\govuk_pay\ApiService $api_service
-   *   The GOV.UK Pay API service.
+   *   The API service.
    * @param \Drupal\Component\Uuid\UuidInterface $uuid_service
    *   The UUID service.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -93,9 +108,11 @@ class GovUkPayWebformService {
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
    * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The temp store factory.
+   *   The tempstore factory.
    * @param \Drupal\Core\Utility\Token $token
    *   The token service.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
@@ -106,15 +123,18 @@ class GovUkPayWebformService {
     LoggerChannelFactoryInterface $logger_factory,
     PrivateTempStoreFactory $temp_store_factory,
     Token $token,
+    AccountProxyInterface $current_user,
   ) {
     $this->configFactory = $config_factory;
     $this->apiService = $api_service;
     $this->uuidService = $uuid_service;
     $this->requestStack = $request_stack;
     $this->entityTypeManager = $entity_type_manager;
+    $this->loggerFactory = $logger_factory;
     $this->logger = $logger_factory->get('govuk_pay_webform');
     $this->tempStore = $temp_store_factory->get('govuk_pay_webform');
     $this->token = $token;
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -211,17 +231,16 @@ class GovUkPayWebformService {
       $metadata
     );
 
-    $payment = GovUkPayment::create([
-      'payment_id' => $payment_response->getPaymentId(),
-      'amount' => $amount,
-      'uuid' => $uuid,
-      'status' => $payment_response->getState()->getStatus(),
-      'webform_id' => $webform->id(),
-      'submission_id' => $sid,
-      'payment_for' => $payment_for,
-      'payment_reference' => $payment_reference,
-    ]);
-    $payment->save();
+    // Create the payment entity and get the next URL from the response.
+    $this->createPaymentEntity(
+      $payment_response,
+      $uuid,
+      $amount,
+      $webform->id(),
+      $sid,
+      $payment_for,
+      $payment_reference,
+    );
 
     $links = $payment_response->getLinks();
     $nextUrl = $links['next_url']->getHref() ?? NULL;
@@ -450,6 +469,61 @@ class GovUkPayWebformService {
     ];
 
     return $this->token->replace($text, $token_data);
+  }
+
+  /**
+   * Create a payment entity from a payment response.
+   *
+   * @param \Swagger\Client\Model\CreatePaymentResult $payment_response
+   *   The payment response from the GOV.UK Pay API.
+   * @param string $uuid
+   *   The UUID for the payment.
+   * @param int $amount
+   *   The payment amount in pence.
+   * @param string $webform_id
+   *   The webform ID.
+   * @param string $submission_id
+   *   The submission ID.
+   * @param string $payment_for
+   *   The payment description.
+   * @param string $payment_reference
+   *   The payment reference.
+   *
+   * @return \Drupal\govuk_pay\Entity\GovUkPayment
+   *   The created payment entity.
+   */
+  public function createPaymentEntity(
+    $payment_response,
+    $uuid,
+    $amount,
+    $webform_id,
+    $submission_id,
+    $payment_for,
+    $payment_reference,
+  ) {
+    $payment = GovUkPayment::create([
+      'payment_id' => $payment_response->getPaymentId(),
+      'amount' => $amount,
+      'uuid' => $uuid,
+      'status' => $payment_response->getState()->getStatus(),
+      'webform_id' => $webform_id,
+      'submission_id' => $submission_id,
+      'payment_for' => $payment_for,
+      'payment_reference' => $payment_reference,
+    ]);
+
+    // Set up the initial revision.
+    $payment->setNewRevision(TRUE);
+    $payment->setRevisionCreationTime(time());
+    $payment->setRevisionLogMessage('Payment created with initial status: ' . $payment_response->getState()->getStatus());
+
+    // Set the revision owner to the current user if available.
+    if ($this->currentUser) {
+      $payment->setRevisionUserId($this->currentUser->id());
+    }
+
+    $payment->save();
+    return $payment;
   }
 
 }

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -5,10 +5,11 @@ namespace Drupal\govuk_pay\Entity;
 use Drupal\user\EntityOwnerTrait;
 use Drupal\govuk_pay\GovUkPaymentInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\RevisionableContentEntityBase;
+use Drupal\Core\Entity\RevisionLogEntityTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
-use Drupal\Core\Entity\ContentEntityBase;
 
 /**
  * Defines the GovUkPayment entity.
@@ -17,6 +18,7 @@ use Drupal\Core\Entity\ContentEntityBase;
  *   id = "govukpayment",
  *   label = @Translation("GOV.UK Payment"),
  *   base_table = "govukpayment",
+ *   revision_table = "govukpayment_revision",
  *   admin_permission = "administer govukpayment entity",
  *   fieldable = FALSE,
  *   handlers = {
@@ -40,6 +42,8 @@ use Drupal\Core\Entity\ContentEntityBase;
  *     "payment_for" = "payment_for",
  *     "payment_reference" = "payment_reference",
  *     "owner" = "uid",
+ *     "revision" = "vid",
+ *     "revision_translation_affected" = "revision_translation_affected",
  *   },
  *   config_export = {
  *     "id",
@@ -52,14 +56,20 @@ use Drupal\Core\Entity\ContentEntityBase;
  *     "payment_for",
  *     "payment_reference",
  *     "uid",
+ *   },
+ *   revision_metadata_keys = {
+ *     "revision_user" = "revision_user",
+ *     "revision_created" = "revision_created",
+ *     "revision_log_message" = "revision_log_message"
  *   }
  * )
  */
-class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
+class GovUkPayment extends RevisionableContentEntityBase implements GovUkPaymentInterface {
 
   // Implements methods defined by EntityChangedInterface.
   use EntityChangedTrait;
   use EntityOwnerTrait;
+  use RevisionLogEntityTrait;
 
   /**
    * {@inheritdoc}
@@ -120,7 +130,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -6,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['webform_id'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Webform ID'))
@@ -135,7 +146,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -6,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['submission_id'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Submission ID'))
@@ -150,7 +162,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -6,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['status'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Status'))
@@ -165,7 +178,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -6,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['amount'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Amount'))
@@ -180,7 +194,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -6,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['payment_for'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Payment For'))
@@ -195,7 +210,8 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -5,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['payment_reference'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Payment Reference'))
@@ -210,14 +226,43 @@ class GovUkPayment extends ContentEntityBase implements GovUkPaymentInterface {
         'type' => 'string',
         'weight' => -4,
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setRevisionable(TRUE);
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
-      ->setDescription(t('The time that the entity was created.'));
+      ->setDescription(t('The time that the entity was created.'))
+      ->setRevisionable(TRUE);
+
     $fields['changed'] = BaseFieldDefinition::create('changed')
       ->setLabel(t('Changed'))
-      ->setDescription(t('The time that the entity was last edited.'));
+      ->setDescription(t('The time that the entity was last edited.'))
+      ->setRevisionable(TRUE);
+
+    // Revision metadata fields.
+    $fields['revision_created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Revision created'))
+      ->setDescription(t('The time that the current revision was created.'))
+      ->setRevisionable(TRUE);
+
+    $fields['revision_user'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Revision user'))
+      ->setDescription(t('The user ID of the author of the current revision.'))
+      ->setSetting('target_type', 'user')
+      ->setRevisionable(TRUE);
+
+    $fields['revision_log_message'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('Revision log message'))
+      ->setDescription(t('Briefly describe the changes you have made.'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue('')
+      ->setDisplayOptions('form', [
+        'type' => 'string_textarea',
+        'weight' => 25,
+        'settings' => [
+          'rows' => 4,
+        ],
+      ]);
 
     return $fields;
   }


### PR DESCRIPTION
## What does this change?

This adds revisions to the entity and updates the status when returning from the gateway (if different). This way changes between statuses can be tracked and potentially visualised using a view.

#14 and #11 