### PR TITLE
1.x session

### DIFF
--- a/modules/govuk_pay_webform/govuk_pay_webform.services.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.services.yml
@@ -17,3 +17,8 @@ services:
     tags:
       - { name: access_check, applies_to: _govuk_pay_webform_access_check }
       - '@token'
+  govuk_pay_webform.redirect_subscriber:
+    class: Drupal\govuk_pay_webform\EventSubscriber\GovUkPayRedirectSubscriber
+    arguments: ['@tempstore.private', '@logger.factory']
+    tags:
+      - { name: event_subscriber }

--- a/modules/govuk_pay_webform/src/EventSubscriber/GovUkPayRedirectSubscriber.php
+++ b/modules/govuk_pay_webform/src/EventSubscriber/GovUkPayRedirectSubscriber.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\govuk_pay_webform\EventSubscriber;
+
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+
+/**
+ * Event subscriber for handling GOV.UK Pay redirects.
+ *
+ * This subscriber listens to the KernelEvents::RESPONSE event and
+ * issues a redirect if one has been stored by the GovUkPayWebformService.
+ */
+class GovUkPayRedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The tempstore service.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a new GovUkPayRedirectSubscriber.
+   *
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct(
+    PrivateTempStoreFactory $temp_store_factory,
+    LoggerChannelFactoryInterface $logger_factory,
+  ) {
+    $this->tempStore = $temp_store_factory->get('govuk_pay_webform');
+    $this->logger = $logger_factory->get('govuk_pay_webform');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Use a high priority to ensure this runs before other response subscribers.
+    $events[KernelEvents::RESPONSE][] = ['onKernelResponse', 100];
+    return $events;
+  }
+
+  /**
+   * Handles the response event by checking for a stored redirect URL.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event.
+   */
+  public function onKernelResponse(ResponseEvent $event) {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    try {
+      // Check if there's a redirect URL stored in the tempStore.
+      $redirect_url = $this->tempStore->get('redirect_url');
+
+      if (!empty($redirect_url)) {
+        // Create and prepare the redirect response.
+        $response = new TrustedRedirectResponse($redirect_url, 302);
+        $response->prepare($event->getRequest());
+
+        // Set the response on the event.
+        $event->setResponse($response);
+
+        // Clear the stored redirect URL to prevent repeated redirects.
+        $this->tempStore->delete('redirect_url');
+      }
+    }
+    catch (\Exception $e) {
+      // Log the error but don't throw an exception to avoid breaking the site.
+      $this->logger->error(
+        'Error processing GOV.UK Pay redirect: @error',
+        ['@error' => $e->getMessage()]
+      );
+    }
+  }
+
+}

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -11,7 +11,6 @@ use Drupal\Core\Utility\Token;
 use Drupal\Core\Url;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -452,8 +451,8 @@ class GovUkPayWebformService {
    * @param \Swagger\Client\Model\CreatePaymentResult $payment_response
    *   The payment response from the GOV.UK Pay API.
    *
-   * @return bool|\Drupal\Core\Routing\TrustedRedirectResponse
-   *   The redirect response if redirect was initiated, FALSE otherwise.
+   * @return bool
+   *   TRUE if redirect URL was stored for later processing, FALSE otherwise.
    */
   protected function handlePaymentRedirect($payment_response) {
     $links = $payment_response->getLinks();
@@ -461,48 +460,15 @@ class GovUkPayWebformService {
 
     if (!is_null($nextUrl)) {
       $request = $this->requestStack->getCurrentRequest();
+      // Ensure a session is initialised for anonymous users.
+      $request->getSession()->save();
 
-      // Initialize the session before creating the response.
-      try {
-        // Only try to save the session if it's already started.
-        if ($request->hasSession() && $request->getSession()->isStarted()) {
-          $request->getSession()->save();
-        }
-      }
-      catch (\Exception $e) {
-        // Log but continue if there's a session error.
-        $this->logger->warning('Session error during payment redirect: @message', ['@message' => $e->getMessage()]);
-      }
-
-      // Create the redirect response.
-      $response = $this->createRedirectResponse($nextUrl->getHref(), $request);
-
-      // In a normal request context, send the response.
-      if (php_sapi_name() != 'cli') {
-        $response->send();
-      }
-
-      return $response;
+      // Store the redirect URL in the tempStore for later processing by the EventSubscriber.
+      $this->tempStore->set('redirect_url', $nextUrl->getHref());
+      return TRUE;
     }
 
     return FALSE;
-  }
-
-  /**
-   * Creates a redirect response.
-   *
-   * @param string $url
-   *   The URL to redirect to.
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The current request.
-   *
-   * @return \Drupal\Core\Routing\TrustedRedirectResponse
-   *   The prepared redirect response.
-   */
-  protected function createRedirectResponse($url, $request) {
-    $response = new TrustedRedirectResponse($url, 302);
-    $response->prepare($request);
-    return $response;
   }
 
   /**

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -460,10 +460,20 @@ class GovUkPayWebformService {
 
     if (!is_null($nextUrl)) {
       $request = $this->requestStack->getCurrentRequest();
-      // Ensure a session is initialised for anonymous users.
-      $request->getSession()->save();
 
-      // Store the redirect URL in the tempStore for later processing by the EventSubscriber.
+      // Ensure a session is initialised for anonymous users.
+      try {
+        if ($request->hasSession()) {
+          $request->getSession()->save();
+        }
+      }
+      catch (\Exception $e) {
+        // Log the session error but continue with the redirect.
+        $this->logger->warning('Session error during payment redirect: @message', ['@message' => $e->getMessage()]);
+      }
+
+      // Store the redirect URL in the tempStore
+      // for later processing by the EventSubscriber.
       $this->tempStore->set('redirect_url', $nextUrl->getHref());
       return TRUE;
     }

--- a/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
@@ -314,11 +314,17 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     $loggerProperty->setAccessible(TRUE);
     $loggerProperty->setValue($this->paymentService, $logger->reveal());
 
+    // We're expecting an exception to be caught internally, not thrown to the test
     // Test session error handling.
-    $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
-    
-    // Verify that despite the session error, we still get TRUE as the result.
-    $this->assertTrue($result);
+    try {
+      $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
+      
+      // Verify that despite the session error, we still get TRUE as the result.
+      $this->assertTrue($result);
+    }
+    catch (\RuntimeException $e) {
+      $this->fail('Exception should be caught internally, not thrown: ' . $e->getMessage());
+    }
   }
 }
 

--- a/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
@@ -12,6 +12,7 @@ use Swagger\Client\Model\CreatePaymentResult;
 use Psr\Log\LoggerInterface;
 use Drupal\govuk_pay_webform\GovUkPayWebformService;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\TempStore\PrivateTempStore;
 
 /**
  * Tests the GOV.UK Pay Webform service.
@@ -271,40 +272,20 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     $requestStackProperty->setAccessible(TRUE);
     $requestStackProperty->setValue($this->paymentService, $request_stack->reveal());
 
-    // Create a mock response to return from our test method.
-    $mockResponse = new TrustedRedirectResponse('https://payments.example.com/pay/123');
+    // Set up the tempStore to expect a set call.
+    $tempStore = $this->prophesize(\Drupal\Core\TempStore\PrivateTempStore::class);
+    $tempStore->set('redirect_url', 'https://payments.example.com/pay/123')->shouldBeCalled();
 
-    // Use reflection to temporarily replace the method.
-    $createRedirectMethod = $reflection->getMethod('createRedirectResponse');
-    $createRedirectMethod->setAccessible(TRUE);
-
-    // We can't actually replace the method at runtime in PHP, so we'll use a different approach.
-    // Instead, we'll create a test double that extends the service class.
-    $testDouble = $this->getMockBuilder(get_class($this->paymentService))
-      ->disableOriginalConstructor()
-      ->setMethods(['createRedirectResponse'])
-      ->getMock();
-
-    // Configure the mock to return our mock response.
-    $testDouble->method('createRedirectResponse')
-      ->willReturn($mockResponse);
-
-    // Copy all properties from the original service to our test double.
-    foreach ($reflection->getProperties() as $property) {
-      if (!$property->isStatic()) {
-        $property->setAccessible(TRUE);
-        $value = $property->getValue($this->paymentService);
-
-        $property->setValue($testDouble, $value);
-      }
-    }
+    // Replace the tempStore in the service.
+    $tempStoreProperty = $reflection->getProperty('tempStore');
+    $tempStoreProperty->setAccessible(TRUE);
+    $tempStoreProperty->setValue($this->paymentService, $tempStore->reveal());
 
     // Test normal session handling.
-    $result = $handlePaymentMethod->invoke($testDouble, $payment_response->reveal());
-
-    // Verify the result is a TrustedRedirectResponse with the correct URL.
-    $this->assertSame($mockResponse, $result);
-    $this->assertEquals('https://payments.example.com/pay/123', $result->getTargetUrl());
+    $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
+    
+    // Verify the result is TRUE.
+    $this->assertTrue($result);
 
     // Test 2: Session error handling
     // Create a mock session that throws an exception.
@@ -321,26 +302,24 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     $request_stack = $this->prophesize(RequestStack::class);
     $request_stack->getCurrentRequest()->willReturn($request->reveal());
 
-    // Replace the request stack in the test double.
-    $requestStackProperty->setValue($testDouble, $request_stack->reveal());
+    // Replace the request stack in the service.
+    $requestStackProperty->setValue($this->paymentService, $request_stack->reveal());
 
     // Set up the logger to expect a warning.
     $logger = $this->prophesize(LoggerInterface::class);
     $logger->warning('Session error during payment redirect: @message', ['@message' => 'Session error'])->shouldBeCalled();
 
-    // Replace the logger in the test double.
+    // Replace the logger in the service.
     $loggerProperty = $reflection->getProperty('logger');
     $loggerProperty->setAccessible(TRUE);
-    $loggerProperty->setValue($testDouble, $logger->reveal());
+    $loggerProperty->setValue($this->paymentService, $logger->reveal());
 
     // Test session error handling.
-    $result = $handlePaymentMethod->invoke($testDouble, $payment_response->reveal());
-
-    // Verify that despite the session error, we still get a redirect response.
-    $this->assertSame($mockResponse, $result);
-    $this->assertEquals('https://payments.example.com/pay/123', $result->getTargetUrl());
+    $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
+    
+    // Verify that despite the session error, we still get TRUE as the result.
+    $this->assertTrue($result);
   }
-
 }
 
 /**

--- a/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
@@ -911,6 +911,73 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
   }
 
   /**
+   * Tests the handlePaymentRedirect method with a valid URL.
+   *
+   * @covers ::handlePaymentRedirect
+   */
+  public function testHandlePaymentRedirectWithUrl() {
+    // Create a mock payment response.
+    $payment_response = $this->createMock('Swagger\Client\Model\CreatePaymentResult');
+
+    // Create a mock Link object for the next_url.
+    $nextUrl = $this->createMock('Swagger\Client\Model\Link');
+    $nextUrl->expects($this->once())
+      ->method('getHref')
+      ->willReturn('https://payments.example.com/pay/123');
+
+    // Create a mock PaymentLinks object.
+    $links = $this->createMock('Swagger\Client\Model\PaymentLinks');
+    $links->expects($this->once())
+      ->method('getNextUrl')
+      ->willReturn($nextUrl);
+
+    // Set up the payment response to return the links.
+    $payment_response->expects($this->once())
+      ->method('getLinks')
+      ->willReturn($links);
+
+    // Create a mock session.
+    $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+    $session->expects($this->once())
+      ->method('save');
+
+    // Create a mock request.
+    $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+    $request->expects($this->once())
+      ->method('getSession')
+      ->willReturn($session);
+
+    // Create a mock request stack.
+    $request_stack = $this->createMock('Symfony\Component\HttpFoundation\RequestStack');
+    $request_stack->expects($this->once())
+      ->method('getCurrentRequest')
+      ->willReturn($request);
+
+    // Create a mock tempStore.
+    $temp_store = $this->createMock('Drupal\Core\TempStore\PrivateTempStore');
+    $temp_store->expects($this->once())
+      ->method('set')
+      ->with('redirect_url', 'https://payments.example.com/pay/123');
+
+    // Create a service with mocked dependencies.
+    $service = $this->createMockService([
+      'requestStack' => $request_stack,
+      'tempStore' => $temp_store,
+    ]);
+
+    // Get the protected method.
+    $reflection = new \ReflectionClass(GovUkPayWebformService::class);
+    $method = $reflection->getMethod('handlePaymentRedirect');
+    $method->setAccessible(TRUE);
+
+    // Call the method under test.
+    $result = $method->invoke($service, $payment_response);
+
+    // Assert the result is TRUE.
+    $this->assertTrue($result);
+  }
+
+  /**
    * Tests the processMetadata method.
    *
    * @covers ::processMetadata

--- a/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
@@ -160,7 +160,14 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
    *   The mock service.
    */
   protected function createMockService(array $methods) {
-    return $this->getMockBuilder(GovUkPayWebformService::class)
+    // If $methods is a simple array of strings, use it directly.
+    // Otherwise, extract the method names from the associative array.
+    $methodNames = array_filter($methods, 'is_string');
+    if (count($methodNames) === 0 && count($methods) > 0) {
+      $methodNames = array_keys($methods);
+    }
+    
+    $mockBuilder = $this->getMockBuilder(GovUkPayWebformService::class)
       ->setConstructorArgs([
         $this->configFactory->reveal(),
         $this->apiService->reveal(),
@@ -171,9 +178,34 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
         $this->tempStoreFactory->reveal(),
         $this->token->reveal(),
         $this->currentUser->reveal(),
-      ])
-      ->onlyMethods(array_keys($methods))
-      ->getMock();
+      ]);
+      
+    if (!empty($methodNames)) {
+      $mockBuilder->onlyMethods($methodNames);
+    }
+    
+    $service = $mockBuilder->getMock();
+    
+    // If $methods is an associative array, set the mocked properties.
+    foreach ($methods as $key => $value) {
+      if (!is_string($key) || !is_object($value)) {
+        continue;
+      }
+      
+      try {
+        $reflection = new \ReflectionClass(GovUkPayWebformService::class);
+        if ($reflection->hasProperty($key)) {
+          $property = $reflection->getProperty($key);
+          $property->setAccessible(TRUE);
+          $property->setValue($service, $value);
+        }
+      }
+      catch (\Exception $e) {
+        // Skip if property doesn't exist or can't be set.
+      }
+    }
+    
+    return $service;
   }
 
   /**
@@ -496,12 +528,29 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
     $webform_submission = $this->prophesize(WebformSubmissionInterface::class);
     $webform_submission->getWebform()->willReturn($webform->reveal());
 
-    // Create a service without mocking any methods.
-    $service = $this->createMockService([]);
+    // Create a service with a mock replaceTokens method to ensure it returns an empty string
+    $service = $this->getMockBuilder(GovUkPayWebformService::class)
+      ->setConstructorArgs([
+        $this->configFactory->reveal(),
+        $this->apiService->reveal(),
+        $this->uuidService->reveal(),
+        $this->requestStack->reveal(),
+        $this->prophesize(EntityTypeManagerInterface::class)->reveal(),
+        $this->loggerFactory->reveal(),
+        $this->tempStoreFactory->reveal(),
+        $this->token->reveal(),
+        $this->currentUser->reveal(),
+      ])
+      ->onlyMethods(['replaceTokens'])
+      ->getMock();
+    
+    // Ensure replaceTokens returns an empty string
+    $service->method('replaceTokens')
+      ->willReturn('');
 
     // Expect an exception to be thrown.
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage('Payment amount could not be determined.');
+    $this->expectExceptionMessage('Payment amount could not be determined');
 
     // Call the method under test.
     $service->calculateAmount($webform_submission->reveal(), $configuration);

--- a/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
@@ -154,10 +154,10 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
    * Creates a mock service with specified methods mocked.
    *
    * @param array $methods
-   *   The methods to mock.
+   *   Methods to mock.
    *
-   * @return \Drupal\govuk_pay_webform\GovUkPayWebformService|\PHPUnit\Framework\MockObject\MockObject
-   *   The mocked service with calculateAmount method available.
+   * @return \PHPUnit\Framework\MockObject\MockObject
+   *   The mock service.
    */
   protected function createMockService(array $methods) {
     return $this->getMockBuilder(GovUkPayWebformService::class)
@@ -172,7 +172,7 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
         $this->token->reveal(),
         $this->currentUser->reveal(),
       ])
-      ->onlyMethods($methods)
+      ->onlyMethods(array_keys($methods))
       ->getMock();
   }
 
@@ -911,41 +911,30 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
   }
 
   /**
-   * Tests the handlePaymentRedirect method with a valid URL.
-   *
-   * @covers ::handlePaymentRedirect
+   * Tests the handlePaymentRedirect method with a URL.
    */
   public function testHandlePaymentRedirectWithUrl() {
     // Create a mock payment response.
     $payment_response = $this->createMock('Swagger\Client\Model\CreatePaymentResult');
+    $links = $this->createMock('Swagger\Client\Model\PaymentLinks');
+    $next_url = $this->createMock('Swagger\Client\Model\Link');
 
-    // Create a mock Link object for the next_url.
-    $nextUrl = $this->createMock('Swagger\Client\Model\Link');
-    $nextUrl->expects($this->once())
+    // Configure the mocks.
+    $next_url->expects($this->once())
       ->method('getHref')
       ->willReturn('https://payments.example.com/pay/123');
-
-    // Create a mock PaymentLinks object.
-    $links = $this->createMock('Swagger\Client\Model\PaymentLinks');
     $links->expects($this->once())
       ->method('getNextUrl')
-      ->willReturn($nextUrl);
-
-    // Set up the payment response to return the links.
+      ->willReturn($next_url);
     $payment_response->expects($this->once())
       ->method('getLinks')
       ->willReturn($links);
 
-    // Create a mock session.
-    $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
-    $session->expects($this->once())
-      ->method('save');
-
     // Create a mock request.
     $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
     $request->expects($this->once())
-      ->method('getSession')
-      ->willReturn($session);
+      ->method('hasSession')
+      ->willReturn(TRUE);
 
     // Create a mock request stack.
     $request_stack = $this->createMock('Symfony\Component\HttpFoundation\RequestStack');
@@ -959,14 +948,23 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
       ->method('set')
       ->with('redirect_url', 'https://payments.example.com/pay/123');
 
-    // Create a service with mocked dependencies.
-    $service = $this->createMockService([
-      'requestStack' => $request_stack,
-      'tempStore' => $temp_store,
-    ]);
+    // Create a service with our mocked dependencies
+    $service = $this->getMockBuilder(GovUkPayWebformService::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    
+    // Set the mocked properties on the service
+    $reflection = new \ReflectionClass(GovUkPayWebformService::class);
+    
+    $requestStackProperty = $reflection->getProperty('requestStack');
+    $requestStackProperty->setAccessible(TRUE);
+    $requestStackProperty->setValue($service, $request_stack);
+    
+    $tempStoreProperty = $reflection->getProperty('tempStore');
+    $tempStoreProperty->setAccessible(TRUE);
+    $tempStoreProperty->setValue($service, $temp_store);
 
     // Get the protected method.
-    $reflection = new \ReflectionClass(GovUkPayWebformService::class);
     $method = $reflection->getMethod('handlePaymentRedirect');
     $method->setAccessible(TRUE);
 


### PR DESCRIPTION
## What does this change?

This adds an event subscriber that subscribes to the `KernelEvents::RESPONSE` event. It solves the problem of issuing a `TrustedRedirectResponse` directly in the `postSave` method of the handler. Instead the handler stores the needed information for the redirect temporarily and then once the response event it triggered the redirect is issued. This should allow other webform handlers to complete and it should also fix the logged exception:

```
RuntimeException: Failed to start the session because headers have already been sent by "/var/www/html/vendor/symfony/http-foundation/Response.php" at line 431. in Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->start() (line 132 of /var/www/html/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php)
#0 /var/www/html/web/core/lib/Drupal/Core/Session/SessionManager.php(162): Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->start()
#1 /var/www/html/web/core/lib/Drupal/Core/Session/SessionManager.php(193): Drupal\Core\Session\SessionManager->startNow()
#2 /var/www/html/vendor/symfony/http-foundation/Session/Session.php(171): Drupal\Core\Session\SessionManager->save()
...
```