### PR TITLE
feat: Make submission id a ref for Views

### DIFF
--- a/config/schema/govuk_pay.schema.yml
+++ b/config/schema/govuk_pay.schema.yml
@@ -8,3 +8,8 @@ govuk_pay.settings:
       type: string
       label: 'GOV.UK Pay API key'
       description: 'The API key used for authenticating with the GOV.UK Pay service.'
+    gov_pay__reference:
+      type: string
+      label: 'GOV.UK Pay reference'
+      description: 'The fallback reference sent to the GOV.UK Pay service.'
+      

--- a/modules/govuk_pay_webform/govuk_pay_webform.install
+++ b/modules/govuk_pay_webform/govuk_pay_webform.install
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the GOV.UK Pay Webform module.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Updates the entity schema to add webform-related fields to the govukpayment
+ * entity.
+ */
+function govuk_pay_webform_install() {
+  // Update the entity type definition to include our fields.
+  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = $definition_update_manager->getEntityType('govukpayment');
+
+  // Only proceed if the entity type exists.
+  if ($entity_type) {
+    // Get the field definitions from our hook_entity_base_field_info_alter().
+    $fields = [];
+    govuk_pay_webform_entity_base_field_info_alter($fields, $entity_type);
+
+    // Add the webform_id field if it doesn't exist.
+    $field_storage_definition = $definition_update_manager->getFieldStorageDefinition(
+      'webform_id',
+      'govukpayment'
+    );
+    if (!$field_storage_definition && isset($fields['webform_id'])) {
+      $definition_update_manager->installFieldStorageDefinition(
+        'webform_id',
+        'govukpayment',
+        'govuk_pay_webform',
+        $fields['webform_id']
+      );
+      \Drupal::messenger()->addStatus(
+        t('Added webform_id field to govukpayment entity.')
+      );
+    }
+
+    // Add the submission_id field if it doesn't exist.
+    $field_storage_definition = $definition_update_manager->getFieldStorageDefinition(
+      'submission_id',
+      'govukpayment'
+    );
+    if (!$field_storage_definition && isset($fields['submission_id'])) {
+      $definition_update_manager->installFieldStorageDefinition(
+        'submission_id',
+        'govukpayment',
+        'govuk_pay_webform',
+        $fields['submission_id']
+      );
+      \Drupal::messenger()->addStatus(
+        t('Added submission_id field to govukpayment entity.')
+      );
+    }
+  }
+}

--- a/modules/govuk_pay_webform/govuk_pay_webform.module
+++ b/modules/govuk_pay_webform/govuk_pay_webform.module
@@ -30,11 +30,39 @@ function govuk_pay_webform_theme($existing, $type, $theme, $path) {
 /**
  * Implements hook_entity_base_field_info_alter().
  *
- * Adds a submission_id entity reference field to govukpayment entities.
+ * Adds webform-related entity reference fields to govukpayment entities.
  */
 function govuk_pay_webform_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
   if ($entity_type->id() === 'govukpayment') {
+    // Add webform_id as an entity reference to webform entities.
+    $fields['webform_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setName('webform_id')
+      ->setLabel(t('Webform'))
+      ->setDescription(t('The Webform entity referenced by this GovUKPayment.'))
+      ->setSetting('target_type', 'webform')
+      ->setSetting('handler', 'default')
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'entity_reference_label',
+        'weight' => -7,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => -7,
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ],
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setRevisionable(TRUE);
+
+    // Add submission_id as an entity reference to webform_submission entities.
     $fields['submission_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setName('submission_id')
       ->setLabel(t('Submission ID'))
       ->setDescription(t('The Webform Submission entity referenced by this GovUKPayment.'))
       ->setSetting('target_type', 'webform_submission')

--- a/modules/govuk_pay_webform/govuk_pay_webform.module
+++ b/modules/govuk_pay_webform/govuk_pay_webform.module
@@ -5,6 +5,9 @@
  * Provides basic integration with the GOV.UK Pay system.
  */
 
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\EntityTypeInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -22,4 +25,37 @@ function govuk_pay_webform_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ *
+ * Adds a submission_id entity reference field to govukpayment entities.
+ */
+function govuk_pay_webform_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+  if ($entity_type->id() === 'govukpayment') {
+    $fields['submission_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Submission ID'))
+      ->setDescription(t('The Webform Submission entity referenced by this GovUKPayment.'))
+      ->setSetting('target_type', 'webform_submission')
+      ->setSetting('handler', 'default')
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'entity_reference_label',
+        'weight' => -6,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => -6,
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ],
+      ])
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setRevisionable(TRUE);
+  }
 }

--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -542,8 +542,8 @@ class GovUkPayWebformService {
     $query = $this->entityTypeManager->getStorage('govukpayment')->getQuery();
 
     $query->condition('uuid', $uuid);
-    $query->condition('webform_id', $webform_id);
-    $query->condition('submission_id', $submission_id);
+    $query->condition('webform_id.target_id', $webform_id);
+    $query->condition('submission_id.target_id', $submission_id);
     $query->accessCheck(FALSE);
     $result = $query->execute();
 
@@ -743,8 +743,8 @@ class GovUkPayWebformService {
       'amount' => $amount,
       'uuid' => $uuid,
       'status' => $payment_response->getState()->getStatus(),
-      'webform_id' => $webform_id,
-      'submission_id' => $submission_id,
+      'webform_id' => ['target_id' => $webform_id],
+      'submission_id' => ['target_id' => $submission_id],
       'payment_for' => $payment_for,
       'payment_reference' => $payment_reference,
     ]);

--- a/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\govuk_pay_webform\Kernel;
 
+use Drupal\Core\TempStore\PrivateTempStore;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,7 +13,6 @@ use Swagger\Client\Model\CreatePaymentResult;
 use Psr\Log\LoggerInterface;
 use Drupal\govuk_pay_webform\GovUkPayWebformService;
 use Drupal\Core\Routing\TrustedRedirectResponse;
-use Drupal\Core\TempStore\PrivateTempStore;
 
 /**
  * Tests the GOV.UK Pay Webform service.
@@ -192,8 +192,8 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     $this->assertEquals($amount, $payment->amount->value, 'Amount was set correctly.');
     $this->assertEquals($uuid, $payment->uuid->value, 'UUID was set correctly.');
     $this->assertEquals($payment_status, $payment->status->value, 'Status was set correctly.');
-    $this->assertEquals($webform_id, $payment->webform_id->value, 'Webform ID was set correctly.');
-    $this->assertEquals($submission_id, $payment->submission_id->value, 'Submission ID was set correctly.');
+    $this->assertEquals($webform_id, $payment->webform_id->target_id, 'Webform ID was set correctly.');
+    $this->assertEquals($submission_id, $payment->submission_id->target_id, 'Submission ID was set correctly.');
     $this->assertEquals($payment_for, $payment->payment_for->value, 'Payment for was set correctly.');
     $this->assertEquals($payment_reference, $payment->payment_reference->value, 'Payment reference was set correctly.');
   }
@@ -273,7 +273,7 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     $requestStackProperty->setValue($this->paymentService, $request_stack->reveal());
 
     // Set up the tempStore to expect a set call.
-    $tempStore = $this->prophesize(\Drupal\Core\TempStore\PrivateTempStore::class);
+    $tempStore = $this->prophesize(PrivateTempStore::class);
     $tempStore->set('redirect_url', 'https://payments.example.com/pay/123')->shouldBeCalled();
 
     // Replace the tempStore in the service.
@@ -283,7 +283,7 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
 
     // Test normal session handling.
     $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
-    
+
     // Verify the result is TRUE.
     $this->assertTrue($result);
 
@@ -318,7 +318,7 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
     // Test session error handling.
     try {
       $result = $handlePaymentMethod->invoke($this->paymentService, $payment_response->reveal());
-      
+
       // Verify that despite the session error, we still get TRUE as the result.
       $this->assertTrue($result);
     }
@@ -326,6 +326,7 @@ class GovUkPayWebformServiceTest extends GovUkPayWebformTestBase {
       $this->fail('Exception should be caught internally, not thrown: ' . $e->getMessage());
     }
   }
+
 }
 
 /**

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -34,7 +34,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     "id" = "id",
  *     "payment_id" = "payment_id",
  *     "uuid" = "uuid",
- *     "webform_id" = "webform_id",
  *     "status" = "status",
  *     "amount" = "amount",
  *     "uid" = "uid",
@@ -48,7 +47,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     "id",
  *     "payment_id",
  *     "uuid",
- *     "webform_id",
  *     "status",
  *     "amount",
  *     "payment_for",
@@ -131,22 +129,7 @@ class GovUkPayment extends RevisionableContentEntityBase implements GovUkPayment
       ->setDisplayConfigurable('view', TRUE)
       ->setRevisionable(TRUE);
 
-    $fields['webform_id'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Webform ID'))
-      ->setDescription(t('The Webform ID  of the GovUKPayment entity.'))
-      ->setSettings([
-        'default_value' => '',
-        'max_length' => 255,
-        'text_processing' => 0,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'string',
-        'weight' => -6,
-      ])
-      ->setDisplayConfigurable('view', TRUE)
-      ->setRevisionable(TRUE);
-
+    // Removed webform_id field to decouple govuk_pay from webform.
     $fields['status'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Status'))
       ->setDescription(t('The last saved Status of the GovUKPayment entity.'))

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -35,7 +35,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     "payment_id" = "payment_id",
  *     "uuid" = "uuid",
  *     "webform_id" = "webform_id",
- *     "submission_id" = "submission_id",
  *     "status" = "status",
  *     "amount" = "amount",
  *     "uid" = "uid",
@@ -50,7 +49,6 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     "payment_id",
  *     "uuid",
  *     "webform_id",
- *     "submission_id",
  *     "status",
  *     "amount",
  *     "payment_for",
@@ -147,32 +145,6 @@ class GovUkPayment extends RevisionableContentEntityBase implements GovUkPayment
         'weight' => -6,
       ])
       ->setDisplayConfigurable('view', TRUE)
-      ->setRevisionable(TRUE);
-
-    // Change submission_id from string to entity_reference to webform_submission.
-    $fields['submission_id'] = BaseFieldDefinition::create('entity_reference')
-      ->setLabel(t('Submission ID'))
-      ->setDescription(t('The Webform Submission entity referenced by this GovUKPayment.'))
-      ->setSetting('target_type', 'webform_submission')
-      ->setSetting('handler', 'default')
-      ->setRequired(TRUE)
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'entity_reference_label',
-        'weight' => -6,
-      ])
-      ->setDisplayOptions('form', [
-        'type' => 'entity_reference_autocomplete',
-        'weight' => -6,
-        'settings' => [
-          'match_operator' => 'CONTAINS',
-          'size' => '60',
-          'autocomplete_type' => 'tags',
-          'placeholder' => '',
-        ],
-      ])
-      ->setDisplayConfigurable('view', TRUE)
-      ->setDisplayConfigurable('form', TRUE)
       ->setRevisionable(TRUE);
 
     $fields['status'] = BaseFieldDefinition::create('string')

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -149,20 +149,30 @@ class GovUkPayment extends RevisionableContentEntityBase implements GovUkPayment
       ->setDisplayConfigurable('view', TRUE)
       ->setRevisionable(TRUE);
 
-    $fields['submission_id'] = BaseFieldDefinition::create('string')
+    // Change submission_id from string to entity_reference to webform_submission.
+    $fields['submission_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Submission ID'))
-      ->setDescription(t('The Webform Submission ID  of the GovUKPayment entity.'))
-      ->setSettings([
-        'default_value' => '',
-        'max_length' => 255,
-        'text_processing' => 0,
-      ])
+      ->setDescription(t('The Webform Submission entity referenced by this GovUKPayment.'))
+      ->setSetting('target_type', 'webform_submission')
+      ->setSetting('handler', 'default')
+      ->setRequired(TRUE)
       ->setDisplayOptions('view', [
         'label' => 'above',
-        'type' => 'string',
+        'type' => 'entity_reference_label',
         'weight' => -6,
       ])
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => -6,
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ],
+      ])
       ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE)
       ->setRevisionable(TRUE);
 
     $fields['status'] = BaseFieldDefinition::create('string')

--- a/tests/src/Kernel/Entity/GovUkPaymentEntityTest.php
+++ b/tests/src/Kernel/Entity/GovUkPaymentEntityTest.php
@@ -90,10 +90,8 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_123456789',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '123',
       'status' => 'created',
-    // £50.00 in pence
+      // £50.00 in pence
       'amount' => 5000,
       'payment_for' => 'Test Payment',
       'payment_reference' => 'REF123',
@@ -106,8 +104,6 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Verify the payment was saved correctly.
     $this->assertNotEmpty($payment->id(), 'Payment entity was saved with an ID.');
     $this->assertEquals('pay_123456789', $payment->payment_id->value, 'Payment ID was saved correctly.');
-    $this->assertEquals('test_payment_form', $payment->webform_id->value, 'Webform ID was saved correctly.');
-    $this->assertEquals('123', $payment->submission_id->value, 'Submission ID was saved correctly.');
     $this->assertEquals('created', $payment->status->value, 'Status was saved correctly.');
     $this->assertEquals(5000, $payment->amount->value, 'Amount was saved correctly.');
     $this->assertEquals('Test Payment', $payment->payment_for->value, 'Payment for was saved correctly.');
@@ -122,10 +118,8 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_987654321',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '456',
       'status' => 'created',
-    // £100.00 in pence
+      // £100.00 in pence
       'amount' => 10000,
       'payment_for' => 'Test Payment 2',
       'payment_reference' => 'REF456',
@@ -145,12 +139,11 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Verify the loaded payment.
     $this->assertNotNull($loaded_payment, 'Payment was loaded successfully.');
     $this->assertEquals('pay_987654321', $loaded_payment->payment_id->value, 'Payment ID was loaded correctly.');
-    $this->assertEquals('test_payment_form', $loaded_payment->webform_id->value, 'Webform ID was loaded correctly.');
-    $this->assertEquals('456', $loaded_payment->submission_id->value, 'Submission ID was loaded correctly.');
     $this->assertEquals('created', $loaded_payment->status->value, 'Status was loaded correctly.');
     $this->assertEquals(10000, $loaded_payment->amount->value, 'Amount was loaded correctly.');
     $this->assertEquals('Test Payment 2', $loaded_payment->payment_for->value, 'Payment for was loaded correctly.');
     $this->assertEquals('REF456', $loaded_payment->payment_reference->value, 'Payment reference was loaded correctly.');
+    $this->assertEquals($this->user->id(), $loaded_payment->getOwnerId(), 'Owner was loaded correctly.');
   }
 
   /**
@@ -160,11 +153,9 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_update_test',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '789',
       'status' => 'created',
-    // £75.00 in pence
-      'amount' => 7500,
+      // £25.00 in pence
+      'amount' => 2500,
       'payment_for' => 'Update Test',
       'payment_reference' => 'REF789',
       'uid' => $this->user->id(),
@@ -187,7 +178,7 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Verify the update.
     $this->assertEquals('success', $updated_payment->status->value, 'Status was updated correctly.');
     $this->assertEquals('pay_update_test', $updated_payment->payment_id->value, 'Payment ID remained unchanged.');
-    $this->assertEquals(7500, $updated_payment->amount->value, 'Amount remained unchanged.');
+    $this->assertEquals(2500, $updated_payment->amount->value, 'Amount remained unchanged.');
   }
 
   /**
@@ -197,11 +188,9 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_revision_test',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '101',
       'status' => 'created',
-    // £150.00 in pence
-      'amount' => 15000,
+      // £75.00 in pence
+      'amount' => 7500,
       'payment_for' => 'Revision Test',
       'payment_reference' => 'REF101',
       'uid' => $this->user->id(),
@@ -227,7 +216,9 @@ class GovUkPaymentEntityTest extends KernelTestBase {
 
     // Verify the revision data.
     $this->assertEquals('submitted', $latest_revision->status->value, 'Status was updated in the new revision.');
-    $this->assertEquals('Payment submitted to GOV.UK Pay', $latest_revision->getRevisionLogMessage(), 'Revision log message was saved correctly.');
+    // Check the revision log message.
+    $log_message = $latest_revision->revision_log_message->value;
+    $this->assertEquals('Payment submitted to GOV.UK Pay', $log_message, 'Revision log message was saved correctly.');
   }
 
   /**
@@ -237,11 +228,9 @@ class GovUkPaymentEntityTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_delete_test',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '202',
       'status' => 'created',
-    // £20.00 in pence
-      'amount' => 2000,
+      // £60.00 in pence
+      'amount' => 6000,
       'payment_for' => 'Delete Test',
       'payment_reference' => 'REF202',
       'uid' => $this->user->id(),

--- a/tests/src/Kernel/PaymentApiIntegrationTest.php
+++ b/tests/src/Kernel/PaymentApiIntegrationTest.php
@@ -183,8 +183,8 @@ class PaymentApiIntegrationTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_status_test',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '456',
+      'webform_id' => ['target_id' => 'test_payment_form'],
+      'submission_id' => ['target_id' => '456'],
       'status' => 'created',
       // £75.00 in pence
       'amount' => 7500,
@@ -245,8 +245,8 @@ class PaymentApiIntegrationTest extends KernelTestBase {
     // Create a payment entity.
     $payment = GovUkPayment::create([
       'payment_id' => 'pay_error_test',
-      'webform_id' => 'test_payment_form',
-      'submission_id' => '789',
+      'webform_id' => ['target_id' => 'test_payment_form'],
+      'submission_id' => ['target_id' => '789'],
       'status' => 'created',
       // £30.00 in pence
       'amount' => 3000,


### PR DESCRIPTION
## What does this change?

Improves the entity so that the submission id is a reference to the submission which allows Views to be constructed with a relationship to the submission entity. For example a link to the submission is able to be added like in this view:

![image](https://github.com/user-attachments/assets/5e18e7da-e841-45e6-91b8-b6347b65eb38)
