### PR TITLE
fix: Tokens that don't resolve should be empty

### DIFF
--- a/modules/govuk_pay_webform/src/GovUkPayWebformService.php
+++ b/modules/govuk_pay_webform/src/GovUkPayWebformService.php
@@ -386,27 +386,13 @@ class GovUkPayWebformService {
     $cardholder_name = NULL;
     $billing_address = NULL;
 
-    // Check if name field is configured and has a value.
-    if (!empty($configuration['fields']['name'])) {
-      $cardholder_name = $this->replaceTokens($configuration['fields']['name'], $webform_submission, TRUE);
-    }
+    $cardholder_name = trim($this->replaceTokens($configuration['fields']['name'], $webform_submission, TRUE)) ?? NULL;
 
-    // Check if address fields are configured and have values.
-    $line1 = !empty($configuration['fields']['address']['line1'])
-      ? $this->replaceTokens($configuration['fields']['address']['line1'], $webform_submission, TRUE)
-      : NULL;
-    $line2 = !empty($configuration['fields']['address']['line2'])
-      ? $this->replaceTokens($configuration['fields']['address']['line2'], $webform_submission, TRUE)
-      : NULL;
-    $postcode = !empty($configuration['fields']['address']['postcode'])
-      ? $this->replaceTokens($configuration['fields']['address']['postcode'], $webform_submission, TRUE)
-      : NULL;
-    $city = !empty($configuration['fields']['address']['city'])
-      ? $this->replaceTokens($configuration['fields']['address']['city'], $webform_submission, TRUE)
-      : NULL;
-    $country = !empty($configuration['fields']['address']['country'])
-      ? $this->replaceTokens($configuration['fields']['address']['country'], $webform_submission, TRUE)
-      : 'GB';
+    $line1 = trim($this->replaceTokens($configuration['fields']['address']['line1'], $webform_submission, TRUE)) ?? NULL;
+    $line2 = trim($this->replaceTokens($configuration['fields']['address']['line2'], $webform_submission, TRUE)) ?? NULL;
+    $postcode = trim($this->replaceTokens($configuration['fields']['address']['postcode'], $webform_submission, TRUE)) ?? NULL;
+    $city = trim($this->replaceTokens($configuration['fields']['address']['city'], $webform_submission, TRUE)) ?? NULL;
+    $country = trim($this->replaceTokens($configuration['fields']['address']['country'], $webform_submission, TRUE)) ?? 'GB';
 
     // Only create billing address if at least line1 is provided.
     if (!empty($line1)) {
@@ -701,11 +687,11 @@ class GovUkPayWebformService {
 
     // Use replacePlain for plain text output (no HTML encoding).
     if ($plain_text) {
-      return $this->token->replacePlain($text, $token_data);
+      return $this->token->replacePlain($text, $token_data, ['clear' => TRUE]);
     }
 
     // Use replace for HTML output (with HTML encoding).
-    return $this->token->replace($text, $token_data);
+    return $this->token->replace($text, $token_data, ['clear' => TRUE]);
   }
 
   /**

--- a/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
+++ b/modules/govuk_pay_webform/tests/src/Unit/GovUkPayWebformServiceTest.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Swagger\Client\Model\PaymentState;
 use Swagger\Client\Model\CreatePaymentResult;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform\WebformInterface;
 use Drupal\govuk_pay_webform\GovUkPayWebformService;
@@ -166,7 +167,7 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
     if (count($methodNames) === 0 && count($methods) > 0) {
       $methodNames = array_keys($methods);
     }
-    
+
     $mockBuilder = $this->getMockBuilder(GovUkPayWebformService::class)
       ->setConstructorArgs([
         $this->configFactory->reveal(),
@@ -179,19 +180,19 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
         $this->token->reveal(),
         $this->currentUser->reveal(),
       ]);
-      
+
     if (!empty($methodNames)) {
       $mockBuilder->onlyMethods($methodNames);
     }
-    
+
     $service = $mockBuilder->getMock();
-    
+
     // If $methods is an associative array, set the mocked properties.
     foreach ($methods as $key => $value) {
       if (!is_string($key) || !is_object($value)) {
         continue;
       }
-      
+
       try {
         $reflection = new \ReflectionClass(GovUkPayWebformService::class);
         if ($reflection->hasProperty($key)) {
@@ -204,7 +205,7 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
         // Skip if property doesn't exist or can't be set.
       }
     }
-    
+
     return $service;
   }
 
@@ -342,48 +343,21 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
    * @covers ::replaceTokens
    */
   public function testReplaceTokensPlainText() {
-    // Create a mock for the token service.
-    $token = $this->prophesize(Token::class);
+    // Set up test data.
+    $text = 'Hello [webform_submission:values:name]!';
+    $webform_submission = $this->createMock(WebformSubmissionInterface::class);
 
-    // Configure the token service to return plain text content.
-    // Use a text with tokens to ensure the token service is called.
-    $text = 'Hello [webform_submission:values:first_name]!';
-    $expected = "Hello John O'Doe!";
+    // Mock the token service to always return a string.
+    $this->token->replacePlain(Argument::any(), Argument::any(), Argument::any())
+      ->willReturn('Hello John Doe!');
 
-    // Set up the token replacement expectation.
-    $webform = $this->prophesize(WebformInterface::class);
-    $webform_submission = $this->prophesize(WebformSubmissionInterface::class);
-    $webform_submission->getWebform()->willReturn($webform->reveal());
-
-    $token_data = [
-      'webform' => $webform->reveal(),
-      'webform_submission' => $webform_submission->reveal(),
-    ];
-
-    // Configure the token service to return the expected string.
-    $token->replacePlain($text, $token_data)->willReturn($expected);
-
-    // Create a service with our mocked token service.
-    $service = $this->createMockService([]);
-
-    // Replace the token service in the mock with our specific token mock.
+    // Use reflection to access the protected method.
     $reflection = new \ReflectionClass(GovUkPayWebformService::class);
-    $property = $reflection->getProperty('token');
-    $property->setAccessible(TRUE);
-    $property->setValue($service, $token->reveal());
-
-    // Get the protected method.
     $method = $reflection->getMethod('replaceTokens');
     $method->setAccessible(TRUE);
-
-    // Call the method and assert the result.
-    $result = $method->invokeArgs($service, [
-      $text,
-      $webform_submission->reveal(),
-      TRUE,
-    ]);
-
-    $this->assertEquals($expected, $result);
+    $result = $method->invoke($this->govUkPayWebformService, $text, $webform_submission, TRUE);
+    $this->assertIsString($result);
+    $this->assertEquals('Hello John Doe!', $result);
   }
 
   /**
@@ -405,34 +379,19 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
     $webform_submission = $this->prophesize(WebformSubmissionInterface::class);
     $webform_submission->getWebform()->willReturn($webform->reveal());
 
-    $token_data = [
-      'webform' => $webform->reveal(),
-      'webform_submission' => $webform_submission->reveal(),
-    ];
+    $token->replace(Argument::any(), Argument::any(), Argument::any())
+      ->willReturn($expected);
 
-    // Configure the token service to return the expected string.
-    $token->replace($text, $token_data)->willReturn($expected);
-
-    // Create a service with our mocked token service.
-    $service = $this->createMockService([]);
-
-    // Replace the token service in the mock with our specific token mock.
-    $reflection = new \ReflectionClass(GovUkPayWebformService::class);
-    $property = $reflection->getProperty('token');
+    // Use reflection to set the token property on the service under test.
+    $reflectionService = new \ReflectionClass(GovUkPayWebformService::class);
+    $property = $reflectionService->getProperty('token');
     $property->setAccessible(TRUE);
-    $property->setValue($service, $token->reveal());
+    $property->setValue($this->govUkPayWebformService, $token->reveal());
 
-    // Get the protected method.
-    $method = $reflection->getMethod('replaceTokens');
+    // Use reflection to access the protected method.
+    $method = $reflectionService->getMethod('replaceTokens');
     $method->setAccessible(TRUE);
-
-    // Call the method and assert the result.
-    $result = $method->invokeArgs($service, [
-      $text,
-      $webform_submission->reveal(),
-      FALSE,
-    ]);
-
+    $result = $method->invoke($this->govUkPayWebformService, $text, $webform_submission->reveal(), FALSE);
     $this->assertEquals($expected, $result);
   }
 
@@ -528,7 +487,7 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
     $webform_submission = $this->prophesize(WebformSubmissionInterface::class);
     $webform_submission->getWebform()->willReturn($webform->reveal());
 
-    // Create a service with a mock replaceTokens method to ensure it returns an empty string
+    // Create a service with a mock replaceTokens method to ensure it returns an empty string.
     $service = $this->getMockBuilder(GovUkPayWebformService::class)
       ->setConstructorArgs([
         $this->configFactory->reveal(),
@@ -543,8 +502,8 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
       ])
       ->onlyMethods(['replaceTokens'])
       ->getMock();
-    
-    // Ensure replaceTokens returns an empty string
+
+    // Ensure replaceTokens returns an empty string.
     $service->method('replaceTokens')
       ->willReturn('');
 
@@ -997,18 +956,18 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
       ->method('set')
       ->with('redirect_url', 'https://payments.example.com/pay/123');
 
-    // Create a service with our mocked dependencies
+    // Create a service with our mocked dependencies.
     $service = $this->getMockBuilder(GovUkPayWebformService::class)
       ->disableOriginalConstructor()
       ->getMock();
-    
-    // Set the mocked properties on the service
+
+    // Set the mocked properties on the service.
     $reflection = new \ReflectionClass(GovUkPayWebformService::class);
-    
+
     $requestStackProperty = $reflection->getProperty('requestStack');
     $requestStackProperty->setAccessible(TRUE);
     $requestStackProperty->setValue($service, $request_stack);
-    
+
     $tempStoreProperty = $reflection->getProperty('tempStore');
     $tempStoreProperty->setAccessible(TRUE);
     $tempStoreProperty->setValue($service, $temp_store);
@@ -1263,11 +1222,17 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
    * @covers ::processCardholderDetails
    */
   public function testProcessCardholderDetailsNameOnly() {
-    // Set up test data with name only.
+    // Set up test data with name only, but include all address keys as empty strings.
     $configuration = [
       'fields' => [
         'name' => '[webform_submission:values:name]',
-        'address' => [],
+        'address' => [
+          'line1' => '',
+          'line2' => '',
+          'postcode' => '',
+          'city' => '',
+          'country' => '',
+        ],
       ],
     ];
 
@@ -1308,26 +1273,25 @@ class GovUkPayWebformServiceTest extends UnitTestCase {
    * @covers ::processCardholderDetails
    */
   public function testProcessCardholderDetailsNone() {
-    // Set up test data with no cardholder details.
+    // Set up test data with all expected keys present but empty.
     $configuration = [
-      'fields' => [],
+      'fields' => [
+        'name' => '',
+        'address' => [
+          'line1' => '',
+          'line2' => '',
+          'postcode' => '',
+          'city' => '',
+          'country' => '',
+        ],
+      ],
     ];
-
-    // Create a mock webform submission.
     $webform_submission = $this->createMock(WebformSubmissionInterface::class);
-
-    // Create a service with necessary mocks.
     $service = $this->createMockService([]);
-
-    // Get the protected method.
     $reflection = new \ReflectionClass(GovUkPayWebformService::class);
     $method = $reflection->getMethod('processCardholderDetails');
     $method->setAccessible(TRUE);
-
-    // Call the method under test.
     $result = $method->invoke($service, $configuration, $webform_submission);
-
-    // Assert the result is NULL.
     $this->assertNull($result);
   }
 


### PR DESCRIPTION
## What does this change?

This should fix the situation where a token in a handler field doesn't resolve to anything. Without this fix the token itself is returned as the field value but with this fix an empty string is returned. This should help if a field is changed or removed but the token still exists in the handler. It seems like a cleaner solution, I don't expect a user would ever want the token as a string to be the value.