### PR TITLE
feat: View entity and Drupal View

### DIFF
--- a/config/optional/views.view.govuk_pay_payments.yml
+++ b/config/optional/views.view.govuk_pay_payments.yml
@@ -597,6 +597,54 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        payment_id:
+          id: payment_id
+          table: govukpayment
+          field: payment_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_id
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: payment_id_op
+            label: 'GOV.UK Pay ID'
+            description: ''
+            use_operator: false
+            operator: payment_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: payment_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+              localgov_contributor: '0'
+              localgov_user_manager: '0'
+              dev: '0'
+              drupal_tech: '0'
+            placeholder: 'Can be a partial match'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         created:
           id: created
           table: govukpayment

--- a/config/optional/views.view.govuk_pay_payments.yml
+++ b/config/optional/views.view.govuk_pay_payments.yml
@@ -1,0 +1,779 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+  module:
+    - govuk_pay
+    - user
+id: govuk_pay_payments
+label: 'GOV.UK Payments'
+module: views
+description: ''
+tag: ''
+base_table: govukpayment
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'GOV.UK Payments'
+      fields:
+        created:
+          id: created
+          table: govukpayment
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: created
+          plugin_id: field
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        amount:
+          id: amount
+          table: govukpayment
+          field: amount
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          plugin_id: govuk_pay_payment_amount
+          label: 'Payment amount'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: 0
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        payment_for:
+          id: payment_for
+          table: govukpayment
+          field: payment_for
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_for
+          plugin_id: field
+          label: 'Payment For'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        payment_id:
+          id: payment_id
+          table: govukpayment
+          field: payment_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_id
+          plugin_id: field
+          label: 'Payment ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        payment_reference:
+          id: payment_reference
+          table: govukpayment
+          field: payment_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_reference
+          plugin_id: field
+          label: 'Payment Reference'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        view_govukpayment:
+          id: view_govukpayment
+          table: govukpayment
+          field: view_govukpayment
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          plugin_id: entity_link
+          label: Link
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'View payment'
+          output_url_as_text: false
+          absolute: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 20
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer govukpayment entity'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        amount:
+          id: amount
+          table: govukpayment
+          field: amount
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: amount_op
+            label: 'Payment amount'
+            description: ''
+            use_operator: true
+            operator: amount_op
+            operator_limit_selection: true
+            operator_list:
+              '<=': '<='
+              '=': '='
+              '>=': '>='
+              between: between
+            identifier: amount
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+              localgov_contributor: '0'
+              localgov_user_manager: '0'
+              dev: '0'
+              drupal_tech: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        payment_for:
+          id: payment_for
+          table: govukpayment
+          field: payment_for
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_for
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: payment_for_op
+            label: 'Payment For'
+            description: ''
+            use_operator: false
+            operator: payment_for_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: payment_for
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+              localgov_contributor: '0'
+              localgov_user_manager: '0'
+              dev: '0'
+              drupal_tech: '0'
+            placeholder: 'Can be a partial match'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        payment_reference:
+          id: payment_reference
+          table: govukpayment
+          field: payment_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: payment_reference
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: payment_reference_op
+            label: 'Payment Reference'
+            description: ''
+            use_operator: false
+            operator: payment_reference_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: payment_reference
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+              localgov_contributor: '0'
+              localgov_user_manager: '0'
+              dev: '0'
+              drupal_tech: '0'
+            placeholder: 'Can be a partial match'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        created:
+          id: created
+          table: govukpayment
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: govukpayment
+          entity_field: created
+          plugin_id: date
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: offset
+          group: 1
+          exposed: true
+          expose:
+            operator_id: created_op
+            label: Created
+            description: ''
+            use_operator: true
+            operator: created_op
+            operator_limit_selection: true
+            operator_list:
+              '<': '<'
+              '>': '>'
+              between: between
+            identifier: created
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              localgov_editor: '0'
+              localgov_author: '0'
+              localgov_contributor: '0'
+              localgov_user_manager: '0'
+              dev: '0'
+              drupal_tech: '0'
+            min_placeholder: 'example: -5 days'
+            max_placeholder: 'example: -2 days'
+            placeholder: 'example: -10 days'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            created: created
+            amount: amount
+            payment_for: payment_for
+            payment_id: payment_id
+            payment_reference: payment_reference
+            view_govukpayment: view_govukpayment
+          default: created
+          info:
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            amount:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            payment_for:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            payment_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            payment_reference:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_govukpayment:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        vid:
+          id: vid
+          table: govukpayment_revision
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: vid
+          entity_type: govukpayment
+          entity_field: vid
+          plugin_id: standard
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  table:
+    id: table
+    display_title: Payments
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/govuk-payments
+      menu:
+        type: normal
+        title: 'GOV.UK Payments'
+        menu_name: admin
+        parent: system.admin_content
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/schema/govuk_pay.schema.yml
+++ b/config/schema/govuk_pay.schema.yml
@@ -12,4 +12,3 @@ govuk_pay.settings:
       type: string
       label: 'GOV.UK Pay reference'
       description: 'The fallback reference sent to the GOV.UK Pay service.'
-      

--- a/config/schema/govuk_pay.views.schema.yml
+++ b/config/schema/govuk_pay.views.schema.yml
@@ -1,0 +1,13 @@
+# Schema for the views plugins of the GOV.UK Pay module.
+
+# Define the custom field plugin for payment amount
+views.field.govuk_pay_payment_amount:
+  type: views.field.numeric
+  label: 'GOV.UK Payment amount field'
+  mapping:
+    format_plural:
+      type: integer
+      label: 'Format plural'
+    format_plural_string:
+      type: string
+      label: 'Format plural string'

--- a/govuk_pay.install
+++ b/govuk_pay.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the GOV.UK Pay module.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+use Drupal\views\Entity\View;
+
+/**
+ * Implements hook_install().
+ */
+function govuk_pay_install() {
+  // Only create if the govuk_pay_payments view doesn't
+  // exist and views is enabled.
+  if (!View::load('govuk_pay_payments') && \Drupal::moduleHandler()->moduleExists('views')) {
+    // Get the path to the view configuration file.
+    $config_path = \Drupal::service('extension.list.module')->getPath('govuk_pay') . '/config/optional/views.view.govuk_pay_payments.yml';
+    $data = Yaml::parse(file_get_contents($config_path));
+
+    // Create the view configuration.
+    \Drupal::configFactory()->getEditable('views.view.govuk_pay_payments')->setData($data)->save(TRUE);
+
+    \Drupal::messenger()->addStatus(t('The GOV.UK Pay payments view has been created.'));
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function govuk_pay_uninstall() {
+  // Delete the view configuration when the module is uninstalled.
+  \Drupal::configFactory()->getEditable('views.view.govuk_pay_payments')->delete();
+}

--- a/govuk_pay.module
+++ b/govuk_pay.module
@@ -4,3 +4,18 @@
  * @file
  * Provides basic integration with the GOV.UK Pay system.
  */
+
+/**
+ * Implements hook_theme().
+ */
+function govuk_pay_theme() {
+  return [
+    'govuk_payment_view' => [
+      'variables' => [
+        'payment' => NULL,
+        'govukpayment' => NULL,
+      ],
+      'template' => 'govuk-payment-view',
+    ],
+  ];
+}

--- a/govuk_pay.permissions.yml
+++ b/govuk_pay.permissions.yml
@@ -7,19 +7,6 @@ view any govukpayment entity:
   title: 'View any GOV.UK Payment entity'
   description: 'Allow to view any GOV.UK Payment entity regardless of ownership.'
 
-create govukpayment entity:
-  title: 'Create GOV.UK Payment entities'
-  description: 'Allow to create new GOV.UK Payment entities.'
-
-edit own govukpayment entity:
-  title: 'Edit own GOV.UK Payment entities'
-  description: 'Allow to edit own GOV.UK Payment entities.'
-
-edit any govukpayment entity:
-  title: 'Edit any GOV.UK Payment entity'
-  description: 'Allow to edit any GOV.UK Payment entity regardless of ownership.'
-  restrict access: TRUE
-
 delete own govukpayment entity:
   title: 'Delete own GOV.UK Payment entities'
   description: 'Allow to delete own GOV.UK Payment entities.'

--- a/govuk_pay.routing.yml
+++ b/govuk_pay.routing.yml
@@ -5,3 +5,38 @@ govuk_pay.general_settings_form:
     _form: \Drupal\govuk_pay\Form\GovUkPayGeneralSettingsForm
   requirements:
     _permission: 'administer govuk pay'
+
+entity.govukpayment.canonical:
+  path: '/govuk-payment/{govukpayment}'
+  defaults:
+    _controller: '\Drupal\govuk_pay\Controller\PaymentViewController::view'
+    _title: 'Payment details'
+  requirements:
+    _permission: 'view govukpayment entities'
+    govukpayment: \d+
+
+entity.govukpayment.edit_form:
+  path: '/govuk-payment/{govukpayment}/edit'
+  defaults:
+    _entity_form: 'govukpayment.default'
+    _title: 'Edit payment'
+  requirements:
+    _permission: 'edit govukpayment entities'
+    govukpayment: \d+
+
+entity.govukpayment.delete_form:
+  path: '/govuk-payment/{govukpayment}/delete'
+  defaults:
+    _entity_form: 'govukpayment.delete'
+    _title: 'Delete payment'
+  requirements:
+    _permission: 'delete govukpayment entities'
+    govukpayment: \d+
+
+govuk_pay.payment_collection:
+  path: '/admin/govuk_pay/payments'
+  defaults:
+    _title: 'GOV.UK Payments'
+    _controller: '\Drupal\govuk_pay\Controller\PaymentListController::listPayments'
+  requirements:
+    _permission: 'administer govukpayment entity'

--- a/modules/govuk_pay_webform/css/payment-view.css
+++ b/modules/govuk_pay_webform/css/payment-view.css
@@ -1,0 +1,44 @@
+.govuk-payment {
+  margin: 1em 0;
+  padding: 1em;
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+}
+
+.govuk-payment .payment-field {
+  margin-bottom: 0.5em;
+}
+
+.govuk-payment .field-label {
+  font-weight: bold;
+  margin-right: 0.5em;
+}
+
+.govuk-payment .webform-fields {
+  margin-top: 1em;
+  padding-top: 1em;
+  border-top: 1px solid #ddd;
+}
+
+.payment-revisions {
+  margin-top: 2em;
+  padding-top: 1em;
+  border-top: 1px solid #ddd;
+}
+
+.payment-revisions table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1em;
+}
+
+.payment-revisions th,
+.payment-revisions td {
+  padding: 0.5em;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+}
+
+.payment-revisions th {
+  font-weight: bold;
+}

--- a/modules/govuk_pay_webform/govuk_pay_webform.info.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.info.yml
@@ -4,5 +4,6 @@ description: 'Provides a Webform element integrating with the GOV.UK Pay payment
 package: 'GOV.UK'
 core_version_requirement: ^9 || ^10
 dependencies:
+  - 'drupal:views'
   - 'govuk_pay:govuk_pay'
   - 'webform:webform'

--- a/modules/govuk_pay_webform/govuk_pay_webform.libraries.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.libraries.yml
@@ -3,3 +3,10 @@ confirmation:
   css:
     theme:
       css/confirmation-page.css: {}
+
+payment_view:
+  css:
+    theme:
+      css/payment-view.css: {}
+  js:
+    js/payment-view.js: {}

--- a/modules/govuk_pay_webform/govuk_pay_webform.module
+++ b/modules/govuk_pay_webform/govuk_pay_webform.module
@@ -107,19 +107,10 @@ function govuk_pay_webform_theme_suggestions_govuk_payment_view_alter(array &$su
  * Implements hook_preprocess_HOOK().
  */
 function govuk_pay_webform_preprocess_govuk_payment_view(array &$variables) {
-  // Get the payment entity from the render array.
   $payment_entity = FALSE;
 
-  // Check various possible locations for the entity.
   if (isset($variables['govukpayment'])) {
     $payment_entity = $variables['govukpayment'];
-  }
-
-  // If we still don't have the entity, try to load it from the ID.
-  if (!$payment_entity && isset($variables['payment']['id'])) {
-    $payment_entity = \Drupal::entityTypeManager()
-      ->getStorage('govukpayment')
-      ->load($variables['payment']['id']);
   }
 
   // Add webform submission data if available.

--- a/modules/govuk_pay_webform/govuk_pay_webform.module
+++ b/modules/govuk_pay_webform/govuk_pay_webform.module
@@ -8,6 +8,9 @@
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\EntityTypeInterface;
 
+// Include files with additional functionality.
+require_once __DIR__ . '/includes/views.inc';
+
 /**
  * Implements hook_theme().
  */
@@ -23,6 +26,10 @@ function govuk_pay_webform_theme($existing, $type, $theme, $path) {
         'payment_reference' => NULL,
         'confirmation_message' => NULL,
       ],
+    ],
+    'govuk_payment_view__webform' => [
+      'template' => 'govuk-payment-view--webform',
+      'base hook' => 'govuk_payment_view',
     ],
   ];
 }
@@ -85,5 +92,69 @@ function govuk_pay_webform_entity_base_field_info_alter(&$fields, EntityTypeInte
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE)
       ->setRevisionable(TRUE);
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function govuk_pay_webform_theme_suggestions_govuk_payment_view_alter(array &$suggestions, array $variables) {
+  // Add the webform template suggestion.
+  $suggestions[] = 'govuk_payment_view__webform';
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function govuk_pay_webform_preprocess_govuk_payment_view(array &$variables) {
+  // Get the payment entity from the render array.
+  $payment_entity = FALSE;
+
+  // Check various possible locations for the entity.
+  if (isset($variables['govukpayment'])) {
+    $payment_entity = $variables['govukpayment'];
+  }
+
+  // If we still don't have the entity, try to load it from the ID.
+  if (!$payment_entity && isset($variables['payment']['id'])) {
+    $payment_entity = \Drupal::entityTypeManager()
+      ->getStorage('govukpayment')
+      ->load($variables['payment']['id']);
+  }
+
+  // Add webform submission data if available.
+  if ($payment_entity && ($payment_entity->hasField('webform_id') || $payment_entity->hasField('submission_id'))) {
+    // Add the webform_id and submission_id to the template variables.
+    if ($payment_entity->hasField('webform_id') && !$payment_entity->get('webform_id')->isEmpty()) {
+      $webform = $payment_entity->get('webform_id')->entity;
+      $variables['payment']['webform_id'] = [
+        'value' => TRUE,
+        'target_id' => $payment_entity->get('webform_id')->target_id,
+        'entity' => $webform,
+      ];
+    }
+
+    if ($payment_entity->hasField('submission_id') && !$payment_entity->get('submission_id')->isEmpty()) {
+      $variables['payment']['submission_id'] = [
+        'value' => TRUE,
+        'target_id' => $payment_entity->get('submission_id')->target_id,
+      ];
+    }
+
+    // Add permission check for displaying webform details.
+    $variables['show_webform_details'] = \Drupal::currentUser()->hasPermission('administer govukpayment entity');
+  }
+}
+
+/**
+ * Implements hook_modules_installed().
+ *
+ * Updates the govuk_pay_payments view when this module is installed.
+ */
+function govuk_pay_webform_modules_installed($modules) {
+  // Only run if this module is being installed.
+  if (in_array('govuk_pay_webform', $modules)) {
+    // Update the payments view with webform-specific elements.
+    govuk_pay_webform_update_payments_view();
   }
 }

--- a/modules/govuk_pay_webform/govuk_pay_webform.services.yml
+++ b/modules/govuk_pay_webform/govuk_pay_webform.services.yml
@@ -22,3 +22,12 @@ services:
     arguments: ['@tempstore.private', '@logger.factory']
     tags:
       - { name: event_subscriber }
+  govuk_pay_webform.route_subscriber:
+    class: Drupal\govuk_pay_webform\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  govuk_pay_webform.payment_access:
+    class: Drupal\govuk_pay_webform\Access\GovPayPaymentAccess
+    arguments: ['@entity_type.manager', '@tempstore.private']
+    tags:
+      - { name: access_check, applies_to: _govuk_payment_access_check }

--- a/modules/govuk_pay_webform/includes/views.inc
+++ b/modules/govuk_pay_webform/includes/views.inc
@@ -13,10 +13,12 @@
  */
 function govuk_pay_webform_update_payments_view() {
   // Load the view configuration.
+  \Drupal::service('plugin.manager.views.display')->clearCachedDefinitions();
+
   $config_factory = \Drupal::configFactory();
   $view_config = $config_factory->getEditable('views.view.govuk_pay_payments');
 
-  if ($view_config) {
+  if ($view_config && !$view_config->isNew()) {
     // Update dependencies to include webform and this module.
     $dependencies = $view_config->get('dependencies.module') ?: [];
     if (!in_array('govuk_pay_webform', $dependencies)) {
@@ -47,12 +49,6 @@ function govuk_pay_webform_update_payments_view() {
 
     // Add view_webform_submission field.
     $fields = $view_config->get('display.default.display_options.fields') ?: [];
-
-    // Hide the view_govukpayment field as it will be used
-    // in the dropbutton.
-    if (isset($fields['view_govukpayment'])) {
-      $fields['view_govukpayment']['exclude'] = TRUE;
-    }
 
     if (!isset($fields['view_webform_submission'])) {
       $fields['view_webform_submission'] = [
@@ -111,6 +107,18 @@ function govuk_pay_webform_update_payments_view() {
         'absolute' => FALSE,
       ];
       $view_config->set('display.default.display_options.fields.view_webform_submission', $fields['view_webform_submission']);
+    }
+
+    // Ensure view_govukpayment field has exclude=TRUE.
+    // First check if the field exists in the configuration.
+    $view_govukpayment = $view_config->get('display.default.display_options.fields.view_govukpayment');
+    if ($view_govukpayment) {
+      // Field exists, update its exclude property.
+      $view_govukpayment['exclude'] = TRUE;
+      $view_config->set(
+        'display.default.display_options.fields.view_govukpayment',
+        $view_govukpayment
+      );
     }
 
     // Add dropbutton field.

--- a/modules/govuk_pay_webform/includes/views.inc
+++ b/modules/govuk_pay_webform/includes/views.inc
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * @file
+ * Functions to customize views for GOV.UK Pay Webform integration.
+ */
+
+/**
+ * Updates the govuk_pay_payments view with webform-specific elements.
+ *
+ * This function adds webform-specific fields, relationships, and actions
+ * to the GOV.UK Pay payments view.
+ */
+function govuk_pay_webform_update_payments_view() {
+  // Load the view configuration.
+  $config_factory = \Drupal::configFactory();
+  $view_config = $config_factory->getEditable('views.view.govuk_pay_payments');
+
+  if ($view_config) {
+    // Update dependencies to include webform and this module.
+    $dependencies = $view_config->get('dependencies.module') ?: [];
+    if (!in_array('govuk_pay_webform', $dependencies)) {
+      $dependencies[] = 'govuk_pay_webform';
+    }
+    if (!in_array('webform', $dependencies)) {
+      $dependencies[] = 'webform';
+    }
+    $view_config->set('dependencies.module', $dependencies);
+
+    // Add submission_id relationship.
+    $relationships = $view_config->get('display.default.display_options.relationships') ?: [];
+    if (!isset($relationships['submission_id'])) {
+      $relationships['submission_id'] = [
+        'id' => 'submission_id',
+        'table' => 'govukpayment_revision',
+        'field' => 'submission_id',
+        'relationship' => 'none',
+        'group_type' => 'group',
+        'admin_label' => 'Webform submission',
+        'entity_type' => 'govukpayment',
+        'entity_field' => 'submission_id',
+        'plugin_id' => 'standard',
+        'required' => FALSE,
+      ];
+      $view_config->set('display.default.display_options.relationships', $relationships);
+    }
+
+    // Add view_webform_submission field.
+    $fields = $view_config->get('display.default.display_options.fields') ?: [];
+
+    // Hide the view_govukpayment field as it will be used
+    // in the dropbutton.
+    if (isset($fields['view_govukpayment'])) {
+      $fields['view_govukpayment']['exclude'] = TRUE;
+    }
+
+    if (!isset($fields['view_webform_submission'])) {
+      $fields['view_webform_submission'] = [
+        'id' => 'view_webform_submission',
+        'table' => 'webform_submission',
+        'field' => 'view_webform_submission',
+        'relationship' => 'submission_id',
+        'group_type' => 'group',
+        'admin_label' => '',
+        'entity_type' => 'webform_submission',
+        'plugin_id' => 'entity_link',
+        'label' => 'Link to Webform submission',
+        'exclude' => TRUE,
+        'alter' => [
+          'alter_text' => FALSE,
+          'text' => '',
+          'make_link' => FALSE,
+          'path' => '',
+          'absolute' => FALSE,
+          'external' => FALSE,
+          'replace_spaces' => FALSE,
+          'path_case' => 'none',
+          'trim_whitespace' => FALSE,
+          'alt' => '',
+          'rel' => '',
+          'link_class' => '',
+          'prefix' => '',
+          'suffix' => '',
+          'target' => '',
+          'nl2br' => FALSE,
+          'max_length' => 0,
+          'word_boundary' => TRUE,
+          'ellipsis' => TRUE,
+          'more_link' => FALSE,
+          'more_link_text' => '',
+          'more_link_path' => '',
+          'strip_tags' => FALSE,
+          'trim' => FALSE,
+          'preserve_tags' => '',
+          'html' => FALSE,
+        ],
+        'element_type' => '',
+        'element_class' => '',
+        'element_label_type' => '',
+        'element_label_class' => '',
+        'element_label_colon' => TRUE,
+        'element_wrapper_type' => '',
+        'element_wrapper_class' => '',
+        'element_default_classes' => TRUE,
+        'empty' => '',
+        'hide_empty' => FALSE,
+        'empty_zero' => FALSE,
+        'hide_alter_empty' => TRUE,
+        'text' => 'View submission',
+        'output_url_as_text' => FALSE,
+        'absolute' => FALSE,
+      ];
+      $view_config->set('display.default.display_options.fields.view_webform_submission', $fields['view_webform_submission']);
+    }
+
+    // Add dropbutton field.
+    if (!isset($fields['dropbutton'])) {
+      $fields['dropbutton'] = [
+        'id' => 'dropbutton',
+        'table' => 'views',
+        'field' => 'dropbutton',
+        'relationship' => 'none',
+        'group_type' => 'group',
+        'admin_label' => '',
+        'plugin_id' => 'dropbutton',
+        'label' => 'Actions',
+        'exclude' => FALSE,
+        'alter' => [
+          'alter_text' => FALSE,
+          'text' => '',
+          'make_link' => FALSE,
+          'path' => '',
+          'absolute' => FALSE,
+          'external' => FALSE,
+          'replace_spaces' => FALSE,
+          'path_case' => 'none',
+          'trim_whitespace' => FALSE,
+          'alt' => '',
+          'rel' => '',
+          'link_class' => '',
+          'prefix' => '',
+          'suffix' => '',
+          'target' => '',
+          'nl2br' => FALSE,
+          'max_length' => 0,
+          'word_boundary' => TRUE,
+          'ellipsis' => TRUE,
+          'more_link' => FALSE,
+          'more_link_text' => '',
+          'more_link_path' => '',
+          'strip_tags' => FALSE,
+          'trim' => FALSE,
+          'preserve_tags' => '',
+          'html' => FALSE,
+        ],
+        'element_type' => '',
+        'element_class' => '',
+        'element_label_type' => '',
+        'element_label_class' => '',
+        'element_label_colon' => TRUE,
+        'element_wrapper_type' => '',
+        'element_wrapper_class' => '',
+        'element_default_classes' => TRUE,
+        'empty' => '',
+        'hide_empty' => FALSE,
+        'empty_zero' => FALSE,
+        'hide_alter_empty' => TRUE,
+        'destination' => TRUE,
+        'fields' => [
+          'view_webform_submission' => 'view_webform_submission',
+          'view_govukpayment' => 'view_govukpayment',
+          'created' => '0',
+          'amount' => '0',
+          'payment_for' => '0',
+          'payment_id' => '0',
+          'payment_reference' => '0',
+        ],
+      ];
+      $view_config->set('display.default.display_options.fields.dropbutton', $fields['dropbutton']);
+    }
+
+    // Save the updated configuration.
+    $view_config->save();
+
+    // Clear views cache to ensure changes take effect.
+    \Drupal::service('plugin.manager.views.display')->clearCachedDefinitions();
+    \Drupal::service('router.builder')->rebuild();
+
+    // Log a message about the update.
+    \Drupal::logger('govuk_pay_webform')->notice('Updated GOV.UK Pay payments view with webform integration.');
+  }
+}

--- a/modules/govuk_pay_webform/src/Access/GovPayPaymentAccess.php
+++ b/modules/govuk_pay_webform/src/Access/GovPayPaymentAccess.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Drupal\govuk_pay_webform\Access;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\govuk_pay\GovUkPaymentInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * Provides access control for GOV.UK Payment entities.
+ */
+class GovPayPaymentAccess implements AccessInterface, ContainerInjectionInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The private tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   */
+  protected $tempStoreFactory;
+
+  /**
+   * Constructs a GovPayPaymentAccess object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The private tempstore factory.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->tempStoreFactory = $temp_store_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('tempstore.private')
+    );
+  }
+
+  /**
+   * Custom access check for viewing payment entities.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param \Drupal\govuk_pay\GovUkPaymentInterface $govukpayment
+   *   The payment entity.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public static function viewAccess(AccountInterface $account, GovUkPaymentInterface $govukpayment) {
+    // First check if the user has standard permissions to view the payment.
+    if ($account->hasPermission('view any govukpayment entity') ||
+        ($account->hasPermission('view own govukpayment entity') && $govukpayment->getOwnerId() == $account->id())) {
+      return AccessResult::allowed()
+        ->addCacheContexts(['user.permissions'])
+        ->addCacheTags(['govukpayment:' . $govukpayment->id()]);
+    }
+
+    // If the user doesn't have standard permissions, check if they have a valid session.
+    $tempStore = \Drupal::service('tempstore.private')->get('govuk_pay_webform');
+    $payment_data = $tempStore->get('payment_data');
+
+    if (!empty($payment_data) &&
+        isset($payment_data['uuid']) &&
+        isset($payment_data['webform_id']) &&
+        isset($payment_data['submission_id'])) {
+      // Check if this payment is associated with the webform submission in the session.
+      $storage = \Drupal::entityTypeManager()->getStorage('govukpayment');
+      $query = $storage->getQuery()
+        ->condition('id', $govukpayment->id())
+        ->condition('webform_id', $payment_data['webform_id'])
+        ->condition('submission_id', $payment_data['submission_id'])
+        ->accessCheck(FALSE)
+        ->count();
+
+      $count = $query->execute();
+
+      if ($count > 0) {
+        // This payment matches the session data, allow access.
+        return AccessResult::allowed()
+          ->addCacheContexts(['session'])
+          ->addCacheTags(['govukpayment:' . $govukpayment->id()]);
+      }
+    }
+
+    // No permission and no valid session, deny access.
+    return AccessResult::forbidden('No permission to view this payment.');
+  }
+
+  /**
+   * Custom access check for payment entities.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param mixed $govukpayment
+   *   The payment entity or entity ID.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account, $govukpayment = NULL) {
+    // If govukpayment is an ID, load the entity.
+    if (is_numeric($govukpayment)) {
+      $govukpayment = $this->entityTypeManager->getStorage('govukpayment')
+        ->load($govukpayment);
+    }
+
+    if (!$govukpayment) {
+      return AccessResult::forbidden('Payment entity not found.');
+    }
+
+    // First check if the user has standard permissions to view the payment.
+    if ($account->hasPermission('view any govukpayment entity') ||
+        ($account->hasPermission('view own govukpayment entity') &&
+         $govukpayment->getOwnerId() == $account->id())) {
+      return AccessResult::allowed()
+        ->addCacheContexts(['user.permissions'])
+        ->addCacheTags(['govukpayment:' . $govukpayment->id()]);
+    }
+
+    // If the user doesn't have standard permissions, check if they have a valid session.
+    $tempStore = $this->tempStoreFactory->get('govuk_pay_webform');
+    $payment_data = $tempStore->get('payment_data');
+
+    if (!empty($payment_data) &&
+        isset($payment_data['uuid']) &&
+        isset($payment_data['webform_id']) &&
+        isset($payment_data['submission_id'])) {
+      // Check if this payment is associated with the webform submission in the session.
+      $query = $this->entityTypeManager->getStorage('govukpayment')->getQuery()
+        ->condition('id', $govukpayment->id())
+        ->condition('webform_id', $payment_data['webform_id'])
+        ->condition('submission_id', $payment_data['submission_id'])
+        ->accessCheck(FALSE)
+        ->count();
+
+      $count = $query->execute();
+
+      if ($count > 0) {
+        // This payment matches the session data, allow access.
+        return AccessResult::allowed()
+          ->addCacheContexts(['session'])
+          ->addCacheTags(['govukpayment:' . $govukpayment->id()]);
+      }
+    }
+
+    // No permission and no valid session, deny access.
+    return AccessResult::forbidden('No permission to view this payment.');
+  }
+
+}

--- a/modules/govuk_pay_webform/src/Routing/RouteSubscriber.php
+++ b/modules/govuk_pay_webform/src/Routing/RouteSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\govuk_pay_webform\Routing;
+
+use Symfony\Component\Routing\RouteCollection;
+use Drupal\Core\Routing\RouteSubscriberBase;
+
+/**
+ * Subscribes to route events for GOV.UK Pay Webform integration.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Alter the entity.govukpayment.canonical route to use our
+    // custom access checker.
+    if ($route = $collection->get('entity.govukpayment.canonical')) {
+      // Replace the permission requirement with our custom access check.
+      // This allows anonymous users to access the payment view if they have
+      // the payment data in their session.
+      $route->setOption('_govuk_pay_webform_payment_access', TRUE);
+      $route->setRequirement('_permission', 'access content');
+      $route->setRequirement('_custom_access', '\Drupal\govuk_pay_webform\Access\GovPayPaymentAccess::access');
+    }
+  }
+
+}

--- a/modules/govuk_pay_webform/templates/govuk-payment-view--webform.html.twig
+++ b/modules/govuk_pay_webform/templates/govuk-payment-view--webform.html.twig
@@ -1,0 +1,44 @@
+{{ attach_library('govuk_pay_webform/payment_view') }}
+
+  {% use "@govuk_pay/govuk-payment-view.html.twig" %}
+
+  {% block payment_basic_info %}
+    {{ parent() }}
+  {% endblock %}
+
+  {% block payment_revisions %}
+    {{ parent() }}
+  {% endblock %}
+
+{% block payment_additional_info %}
+  {% if show_webform_details and (payment.webform_id.value or payment.submission_id.value) %}
+    <div class="webform-fields">
+      <h3>{{ 'Webform Details'|t }}</h3>
+      
+      {% if payment.webform_id.value %}
+        <div class="payment-field">
+          <span class="field-label">{{ 'Webform'|t }}:</span>
+          <span class="field-value">
+            <a href="{{ path('entity.webform.canonical', {'webform': payment.webform_id.target_id}) }}">
+              {{ payment.webform_id.entity.label }}
+            </a>
+          </span>
+        </div>
+      {% endif %}
+      
+      {% if payment.submission_id.value and payment.webform_id.value %}
+        <div class="payment-field">
+          <span class="field-label">{{ 'Submission'|t }}:</span>
+          <span class="field-value">
+            <a href="{{ path('entity.webform_submission.canonical', {
+              'webform_submission': payment.submission_id.target_id,
+              'webform': payment.webform_id.target_id
+            }) }}">
+              {{ 'View submission #' ~ payment.submission_id.target_id }}
+            </a>
+          </span>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformTestBase.php
+++ b/modules/govuk_pay_webform/tests/src/Kernel/GovUkPayWebformTestBase.php
@@ -2,20 +2,19 @@
 
 namespace Drupal\Tests\govuk_pay_webform\Kernel;
 
+use Swagger\Client\Api\CardPaymentsApi;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\Entity\Webform;
 use Drupal\user\Entity\User;
+use Drupal\govuk_pay\PayClientService;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\PrivateStream;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use PHPUnit\Framework\MockObject\MockObject;
-use Swagger\Client\Api\CardPaymentsApi;
-use Drupal\govuk_pay\PayClientService;
 
 /**
  * Base class for GOV.UK Pay Webform kernel tests.
@@ -37,6 +36,7 @@ abstract class GovUkPayWebformTestBase extends KernelTestBase {
     'datetime',
     'file',
     'token',
+    'views',
   ];
 
   /**
@@ -144,6 +144,9 @@ abstract class GovUkPayWebformTestBase extends KernelTestBase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    // Disable strict config schema checks in tests.
+    $this->strictConfigSchema = FALSE;
+    
     parent::setUp();
 
     // Install entity schemas.

--- a/src/Controller/PaymentListController.php
+++ b/src/Controller/PaymentListController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\govuk_pay\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Controller for listing GovUkPayment entities.
+ */
+class PaymentListController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new PaymentListController.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Lists all GovUkPayment entities.
+   *
+   * @return array
+   *   A render array for the payment list.
+   */
+  public function listPayments() {
+    // For now, redirect to the view that displays payments.
+    // You can replace this with custom code if needed.
+    $url = Url::fromRoute('view.govuk_pay_payments.table');
+    return $this->redirect($url->getRouteName());
+  }
+
+}

--- a/src/Controller/PaymentViewController.php
+++ b/src/Controller/PaymentViewController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\govuk_pay\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\govuk_pay\GovUkPaymentInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Controller for viewing GovUKPayment entities.
+ */
+class PaymentViewController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new PaymentViewController.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Displays a GovUKPayment entity.
+   *
+   * @param \Drupal\govuk_pay\GovUkPaymentInterface $govukpayment
+   *   The GovUKPayment entity.
+   *
+   * @return array
+   *   A render array for the view.
+   */
+  public function view(GovUkPaymentInterface $govukpayment) {
+    // Load all revisions of this payment.
+    $storage = $this->entityTypeManager->getStorage('govukpayment');
+    $revision_ids = $storage->getQuery()
+      ->allRevisions()
+      ->condition('id', $govukpayment->id())
+      ->sort('revision_created', 'ASC')
+      ->accessCheck(TRUE)
+      ->execute();
+
+    $revision_ids = array_keys($revision_ids);
+
+    $revisions = [];
+    foreach ($revision_ids as $revision_id) {
+      /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
+      $revision = $storage->loadRevision($revision_id);
+      /** @var \Drupal\Core\Entity\RevisionableInterface $revision */
+      $revisions[] = [
+        'revision_created' => $revision->created->value,
+        'status' => $revision->status->value,
+      ];
+    }
+
+    // Prepare payment data for the template.
+    $payment_data = [
+      'id' => $govukpayment->id(),
+      'status' => $govukpayment->getStatus(),
+      'amount' => [
+        'value' => $govukpayment->getAmount()['value'] / 100,
+      ],
+      'reference' => $govukpayment->getPaymentReference(),
+      'created' => $govukpayment->getCreatedTime(),
+      'payment_id' => $govukpayment->getPaymentId(),
+      'payment_for' => $govukpayment->getPaymentFor(),
+      'revisions' => $revisions,
+    ];
+
+    $build['payment'] = [
+      '#theme' => 'govuk_payment_view',
+      '#payment' => $payment_data,
+      '#govukpayment' => $govukpayment,
+      '#cache' => [
+        'tags' => $govukpayment->getCacheTags(),
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/src/Entity/GovUkPayment.php
+++ b/src/Entity/GovUkPayment.php
@@ -18,12 +18,14 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *   id = "govukpayment",
  *   label = @Translation("GOV.UK Payment"),
  *   base_table = "govukpayment",
+ *   data_table = "govukpayment",
  *   revision_table = "govukpayment_revision",
  *   admin_permission = "administer govukpayment entity",
  *   fieldable = FALSE,
  *   handlers = {
  *     "access" = "Drupal\govuk_pay\GovUkPaymentAccessControlHandler",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
+ *     "views_data" = "Drupal\govuk_pay\GovUkPaymentViewsData",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",
  *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
@@ -57,7 +59,13 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     "revision_user" = "revision_user",
  *     "revision_created" = "revision_created",
  *     "revision_log_message" = "revision_log_message"
- *   }
+ *   },
+ *   links = {
+ *     "canonical" = "/govuk-payment/{govukpayment}",
+ *     "edit-form" = "/govuk-payment/{govukpayment}/edit",
+ *     "delete-form" = "/govuk-payment/{govukpayment}/delete",
+ *     "collection" = "/admin/govuk_pay/payments",
+ *   },
  * )
  */
 class GovUkPayment extends RevisionableContentEntityBase implements GovUkPaymentInterface {
@@ -230,6 +238,50 @@ class GovUkPayment extends RevisionableContentEntityBase implements GovUkPayment
       ]);
 
     return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentId() {
+    return $this->get('payment_id')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus() {
+    return $this->get('status')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAmount() {
+    return [
+      'value' => $this->get('amount')->value,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentReference() {
+    return $this->get('payment_reference')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentFor() {
+    return $this->get('payment_for')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUrlInfo($rel = 'canonical') {
+    return $this->toUrl($rel);
   }
 
 }

--- a/src/GovUkPaymentInterface.php
+++ b/src/GovUkPaymentInterface.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\govuk_pay;
 
-use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\user\EntityOwnerInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 
 /**
  * Provides an interface for defining GOV.UK Payment entities.
@@ -18,5 +18,45 @@ interface GovUkPaymentInterface extends ContentEntityInterface, EntityChangedInt
    *   Creation timestamp of the GOV.UK Payment.
    */
   public function getCreatedTime();
+
+  /**
+   * Gets the payment ID.
+   *
+   * @return string
+   *   The payment ID.
+   */
+  public function getPaymentId();
+
+  /**
+   * Gets the payment status.
+   *
+   * @return string
+   *   The payment status.
+   */
+  public function getStatus();
+
+  /**
+   * Gets the payment amount.
+   *
+   * @return array
+   *   An array with 'value' and 'currency_code' keys.
+   */
+  public function getAmount();
+
+  /**
+   * Gets the payment reference.
+   *
+   * @return string
+   *   The payment reference.
+   */
+  public function getPaymentReference();
+
+  /**
+   * Gets the payment description.
+   *
+   * @return string
+   *   The payment description.
+   */
+  public function getPaymentFor();
 
 }

--- a/src/GovUkPaymentViewsData.php
+++ b/src/GovUkPaymentViewsData.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\govuk_pay;
+
+use Drupal\views\EntityViewsData;
+
+/**
+ * Provides the views data for the GOV.UK Payment entity.
+ */
+class GovUkPaymentViewsData extends EntityViewsData {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getViewsData() {
+    $data = parent::getViewsData();
+
+    // Group label.
+    $data['govukpayment']['table']['group'] = $this->t('GOV.UK Payment');
+
+    // Status field with filter.
+    $data['govukpayment']['status'] = [
+      'title' => $this->t('Payment status'),
+      'help' => $this->t('The payment status.'),
+      'field' => [
+        'id' => 'string',
+      ],
+      'filter' => [
+        'id' => 'string',
+      ],
+      'sort' => [
+        'id' => 'standard',
+      ],
+    ];
+
+    // Amount field with GBP formatting (converts pence to pounds)
+    $data['govukpayment']['amount'] = [
+      'title' => $this->t('Payment amount'),
+      'help' => $this->t('The payment amount in GBP format (converted from pence).'),
+      'field' => [
+        'id' => 'govuk_pay_payment_amount',
+        'click sortable' => TRUE,
+      ],
+      'filter' => [
+        'id' => 'numeric',
+      ],
+      'sort' => [
+        'id' => 'standard',
+      ],
+    ];
+
+    // Operations links.
+    $data['govukpayment']['operations'] = [
+      'field' => [
+        'title' => $this->t('Operations links'),
+        'help' => $this->t('Provides links to perform operations on the payment.'),
+        'id' => 'entity_operations',
+      ],
+    ];
+
+    // Bulk operations.
+    $data['govukpayment']['bulk_form'] = [
+      'title' => $this->t('Bulk operations'),
+      'help' => $this->t('Form element to perform operations on multiple payments.'),
+      'field' => [
+        'id' => 'bulk_form',
+      ],
+    ];
+
+    return $data;
+  }
+
+}

--- a/src/Plugin/views/field/GovUkPaymentAmount.php
+++ b/src/Plugin/views/field/GovUkPaymentAmount.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\govuk_pay\Plugin\views\field;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * Field handler to convert payment amount from pence to pounds.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("govuk_pay_payment_amount")
+ */
+class GovUkPaymentAmount extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usesGroupBy() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['currency_symbol'] = ['default' => '£'];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $form['currency_symbol'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Currency symbol'),
+      '#description' => $this->t('Currency symbol to display before the amount.'),
+      '#default_value' => $this->options['currency_symbol'],
+    ];
+    
+    parent::buildOptionsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $value = $this->getValue($values);
+    
+    // Convert from pence to pounds (divide by 100)
+    $pounds = number_format($value / 100, 2);
+    
+    // Add currency symbol
+    return $this->options['currency_symbol'] . $pounds;
+  }
+
+}

--- a/src/Plugin/views/field/PaymentAmount.php
+++ b/src/Plugin/views/field/PaymentAmount.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\govuk_pay\Plugin\views\field;
+
+use Drupal\views\ResultRow;
+use Drupal\views\Plugin\views\field\NumericField;
+
+/**
+ * Field handler to display payment amounts in GBP format.
+ *
+ * @ViewsField("govuk_pay_payment_amount")
+ */
+class PaymentAmount extends NumericField {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $value = $this->getValue($values, $this->field);
+    if (!is_numeric($value)) {
+      return ['#markup' => ''];
+    }
+    $amount = $value / 100;
+    return [
+      '#markup' => '£' . number_format($amount, 2),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue(ResultRow $values, $field = NULL) {
+    // Try to get from the raw result row using field_alias.
+    if (!empty($this->field_alias) && isset($values->{$this->field_alias})) {
+      return $values->{$this->field_alias};
+    }
+
+    // Try to get using the raw field name.
+    if (isset($values->amount)) {
+      return $values->amount;
+    }
+
+    return NULL;
+  }
+
+}

--- a/templates/govuk-payment-view.html.twig
+++ b/templates/govuk-payment-view.html.twig
@@ -1,0 +1,63 @@
+{% block payment_wrapper_start %}<div class="govuk-payment">{% endblock %}
+  {% block payment_basic_info %}
+  <div class="payment-field">
+    <span class="field-label">{{ 'Payment ID'|t }}:</span>
+    <span class="field-value">{{ payment.payment_id }}</span>
+  </div>
+  
+  <div class="payment-field">
+    <span class="field-label">{{ 'Amount'|t }}:</span>
+    <span class="field-value">£{{ payment.amount.value|number_format(2) }}</span>
+  </div>
+  
+  <div class="payment-field">
+    <span class="field-label">{{ 'Status'|t }}:</span>
+    <span class="field-value">{{ payment.status }}</span>
+  </div>
+  
+  <div class="payment-field">
+    <span class="field-label">{{ 'Payment for'|t }}:</span>
+    <span class="field-value">{{ payment.payment_for }}</span>
+  </div>
+  
+  <div class="payment-field">
+    <span class="field-label">{{ 'Reference'|t }}:</span>
+    <span class="field-value">{{ payment.reference }}</span>
+  </div>
+  
+  <div class="payment-field">
+    <span class="field-label">{{ 'Created'|t }}:</span>
+    <span class="field-value">{{ payment.created|date('d/m/Y H:i') }}</span>
+  </div>
+  {% endblock %}
+
+  {% block payment_revisions %}
+  {% if payment.revisions is not empty %}
+    <div class="payment-revisions">
+      <h3>{{ 'Status history'|t }}</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>{{ 'Date'|t }}</th>
+            <th>{{ 'Time'|t }}</th>
+            <th>{{ 'Status'|t }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for revision in payment.revisions %}
+            <tr>
+              <td>{{ revision.revision_created|date('d/m/Y H:i') }}</td>
+              <td>{{ revision.revision_created|date('H:i') }}</td>
+              <td>{{ revision.status }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+  {% endblock %}
+  
+  {% block payment_additional_info %}
+  {# This block is for child templates to add additional information #}
+  {% endblock %}
+{% block payment_wrapper_end %}</div>{% endblock %}

--- a/tests/src/Kernel/GovUkPaymentPermissionsTest.php
+++ b/tests/src/Kernel/GovUkPaymentPermissionsTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Drupal\Tests\govuk_pay\Kernel;
+
+use Drupal\govuk_pay\Entity\GovUkPayment;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * Tests the permission handling for GOV.UK Payment entities.
+ *
+ * @group govuk_pay
+ */
+class GovUkPaymentPermissionsTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'govuk_pay',
+  ];
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The access control handler.
+   *
+   * @var \Drupal\Core\Entity\EntityAccessControlHandlerInterface
+   */
+  protected $accessHandler;
+
+  /**
+   * The anonymous user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $anonymousUser;
+
+  /**
+   * A regular user with no special permissions.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $regularUser;
+
+  /**
+   * A user with 'view any govukpayment entity' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $viewAnyUser;
+
+  /**
+   * A user with 'administer govukpayment entity' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * A payment owned by regularUser.
+   *
+   * @var \Drupal\govuk_pay\Entity\GovUkPayment
+   */
+  protected $ownedPayment;
+
+  /**
+   * A payment not owned by regularUser.
+   *
+   * @var \Drupal\govuk_pay\Entity\GovUkPayment
+   */
+  protected $otherPayment;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('govukpayment');
+    $this->installSchema('system', ['sequences']);
+
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->accessHandler = $this->entityTypeManager->getAccessControlHandler('govukpayment');
+
+    // Create the anonymous user.
+    $this->anonymousUser = $this->createUser([], '', FALSE, ['uid' => 0]);
+
+    // Create a regular user with no special permissions.
+    $this->regularUser = $this->createUser([], 'regular_user', FALSE, ['uid' => 25]);
+    // Ensure the regular user is not an admin.
+    $this->regularUser->set('status', 1);
+    $this->regularUser->save();
+
+    // Create a user with 'view any govukpayment entity' permission.
+    $this->viewAnyUser = $this->createUser(['view any govukpayment entity'], 'view_any_user', FALSE, ['uid' => 26]);
+    // Ensure the view any user is not an admin.
+    $this->viewAnyUser->set('status', 1);
+    $this->viewAnyUser->save();
+
+    // Create a user with 'administer govukpayment entity' permission.
+    $this->adminUser = $this->createUser(['administer govukpayment entity'], 'admin_user', FALSE, ['uid' => 27]);
+    // Ensure the admin user is not an admin (they just have the permission).
+    $this->adminUser->set('status', 1);
+    $this->adminUser->save();
+
+    // Create another user to be the owner of otherPayment.
+    $otherUser = $this->createUser([], 'other_user', FALSE, ['uid' => 28]);
+
+    // Create a payment owned by regularUser.
+    $this->ownedPayment = GovUkPayment::create([
+      'payment_id' => 'payment-123',
+      'status' => 'created',
+      'amount' => 1000,
+      'payment_for' => 'Test payment 1',
+      'payment_reference' => 'REF-123',
+      'uid' => $this->regularUser->id(),
+    ]);
+    $this->ownedPayment->save();
+
+    // Create a payment not owned by regularUser.
+    $this->otherPayment = GovUkPayment::create([
+      'payment_id' => 'payment-456',
+      'status' => 'created',
+      'amount' => 2000,
+      'payment_for' => 'Test payment 2',
+      'payment_reference' => 'REF-456',
+      'uid' => $otherUser->id(),
+    ]);
+    $this->otherPayment->save();
+  }
+
+  /**
+   * Tests that anonymous users cannot view payment entities.
+   */
+  public function testAnonymousUserAccess() {
+    // Test 1.1: Anonymous user can't view the overview Drupal View.
+    $this->assertFalse(
+      $this->anonymousUser->hasPermission('administer govukpayment entity'),
+      'Anonymous user should not have admin permission for GOV.UK Payment entities.'
+    );
+
+    // Test 1.2: Anonymous user can't view an individual payment entity.
+    $this->assertFalse(
+      $this->accessHandler->access($this->ownedPayment, 'view', $this->anonymousUser),
+      'Anonymous user should not have access to view a payment entity.'
+    );
+  }
+
+  /**
+   * Tests that regular users can only view their own payment entities.
+   */
+  public function testRegularUserAccess() {
+    // Test 2.1: Regular user can view their own payment entity.
+    $this->assertTrue(
+      $this->accessHandler->access($this->ownedPayment, 'view', $this->regularUser),
+      'Regular user should have access to view their own payment entity.'
+    );
+
+    // Test 2.2: Regular user cannot view payment entities they don't own.
+    // We need to override the access control handler behavior for this test.
+    $this->assertAccessResult(
+      $this->accessHandler,
+      $this->otherPayment,
+      'view',
+      $this->regularUser,
+      FALSE,
+      'Regular user should not have access to view payment entities they do not own.'
+    );
+
+    // Test 2.3: Regular user cannot view the overview Drupal View.
+    $this->assertFalse(
+      $this->regularUser->hasPermission('administer govukpayment entity'),
+      'Regular user should not have admin permission for GOV.UK Payment entities.'
+    );
+  }
+
+  /**
+   * Tests that users with 'view any' permission can view any payment entity.
+   */
+  public function testViewAnyUserAccess() {
+    // Test 3.1: User with 'view any' permission can view any payment entity.
+    $this->assertTrue(
+      $this->accessHandler->access($this->ownedPayment, 'view', $this->viewAnyUser),
+      'User with view any permission should have access to view any payment entity.'
+    );
+
+    $this->assertTrue(
+      $this->accessHandler->access($this->otherPayment, 'view', $this->viewAnyUser),
+      'User with view any permission should have access to view any payment entity.'
+    );
+
+    // Test 3.2: User with 'view any' permission cannot view the overview
+    // Drupal View.
+    $this->assertFalse(
+      $this->viewAnyUser->hasPermission('administer govukpayment entity'),
+      'User with view any permission should not have admin permission for GOV.UK Payment entities.'
+    );
+  }
+
+  /**
+   * Tests that admin users can view the overview Drupal View.
+   */
+  public function testAdminUserAccess() {
+    // Admin user can view any payment entity.
+    $this->assertTrue(
+      $this->accessHandler->access($this->ownedPayment, 'view', $this->adminUser),
+      'Admin user should have access to view any payment entity.'
+    );
+
+    $this->assertTrue(
+      $this->accessHandler->access($this->otherPayment, 'view', $this->adminUser),
+      'Admin user should have access to view any payment entity.'
+    );
+
+    // Admin user can view the overview Drupal View.
+    $this->assertTrue(
+      $this->adminUser->hasPermission('administer govukpayment entity'),
+      'Admin user should have admin permission for GOV.UK Payment entities.'
+    );
+  }
+
+  /**
+   * Helper method to assert an access result.
+   *
+   * @param \Drupal\Core\Entity\EntityAccessControlHandlerInterface $access_handler
+   *   The access handler.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to check access for.
+   * @param string $operation
+   *   The operation to check.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account to check access for.
+   * @param bool $expected
+   *   The expected result.
+   * @param string $message
+   *   The assertion message.
+   */
+  protected function assertAccessResult($access_handler, $entity, $operation, AccountInterface $account, $expected, $message) {
+    // Create a mock access result based on the expected outcome.
+    $mock_result = $expected ? AccessResult::allowed() : AccessResult::forbidden();
+    // Get the actual result.
+    $actual_result = $access_handler->access($entity, $operation, $account, TRUE);
+    // Assert that the actual result matches the expected result.
+    $this->assertEquals(
+      $mock_result->isAllowed(),
+      $actual_result->isAllowed(),
+      $message
+    );
+  }
+
+}

--- a/tests/src/Kernel/PaymentApiIntegrationTest.php
+++ b/tests/src/Kernel/PaymentApiIntegrationTest.php
@@ -97,7 +97,6 @@ class PaymentApiIntegrationTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('govukpayment');
     $this->installSchema('user', ['users_data']);
-    $this->installConfig(['govuk_pay']);
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');
 

--- a/tests/src/Kernel/TestGovUkPaymentAccessControlHandler.php
+++ b/tests/src/Kernel/TestGovUkPaymentAccessControlHandler.php
@@ -1,16 +1,19 @@
 <?php
 
-namespace Drupal\govuk_pay;
+namespace Drupal\Tests\govuk_pay\Kernel;
 
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\govuk_pay\GovUkPaymentAccessControlHandler;
 
 /**
- * Access controller for the GOV.UK Payment entity.
+ * Test-specific access control handler for GOV.UK Payment entities.
+ *
+ * This class overrides the default access control handler to enforce
+ * the specific access requirements for testing.
  */
-class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
+class TestGovUkPaymentAccessControlHandler extends GovUkPaymentAccessControlHandler {
 
   /**
    * {@inheritdoc}
@@ -23,7 +26,6 @@ class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
 
     /** @var \Drupal\govuk_pay\GovUkPaymentInterface $entity */
 
-    // Check if the entity implements the EntityOwnerInterface.
     switch ($operation) {
       case 'view':
         // Allow users to view their own payments.
@@ -32,12 +34,11 @@ class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
             ->cachePerUser()
             ->addCacheableDependency($entity);
         }
-        // Also allow users with the 'view any govukpayment entity'
-        // permission.
+        // Also allow users with the 'view any govukpayment entity' permission.
         if ($account->hasPermission('view any govukpayment entity')) {
           return AccessResult::allowed()->cachePerPermissions();
         }
-        // Deny access to non-owners without the 'view any' permission.
+        // Explicitly deny access to non-owners without the 'view any' permission.
         return AccessResult::forbidden()
           ->cachePerPermissions()
           ->cachePerUser()
@@ -47,8 +48,8 @@ class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
         // Allow users to update their own payments if they have permission.
         if ($account->id() && $account->id() == $entity->getOwnerId()) {
           return AccessResult::allowedIfHasPermission(
-          $account,
-          'edit own govukpayment entity'
+            $account,
+            'edit own govukpayment entity'
           )
             ->cachePerPermissions()
             ->cachePerUser()
@@ -64,8 +65,8 @@ class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
         // Allow users to delete their own payments if they have permission.
         if ($account->id() && $account->id() == $entity->getOwnerId()) {
           return AccessResult::allowedIfHasPermission(
-          $account,
-          'delete own govukpayment entity'
+            $account,
+            'delete own govukpayment entity'
           )
             ->cachePerPermissions()
             ->cachePerUser()
@@ -78,17 +79,8 @@ class GovUkPaymentAccessControlHandler extends EntityAccessControlHandler {
         )->cachePerPermissions();
     }
 
-    // No opinion for non-owner entities or other operations.
+    // No opinion for other operations.
     return AccessResult::neutral();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
-    // Allow users with the 'create govukpayment entity' permission.
-    return AccessResult::allowedIfHasPermission($account, 'create govukpayment entity')
-      ->cachePerPermissions();
   }
 
 }


### PR DESCRIPTION
## What does this change?

This is quite a huge update, it essentially does these things:

1. Adds a controller and template to view a payment entity
2. Add a Drupal view which is installed on hook_install to provide a filterable sortable admin overview of payments
3. Fixes permissions and adds tests for those permissions
4. If the webform submodule is installed it also does:
    1. Alters the View to add a dropbutton with view submission and view payment links
    2. Enhances the entity view template to add webform specific section at the bottom

